### PR TITLE
fix: use expanded folder icons

### DIFF
--- a/packages/explorer-view/src/parts/GetFileIcons/GetFileIcons.ts
+++ b/packages/explorer-view/src/parts/GetFileIcons/GetFileIcons.ts
@@ -3,7 +3,6 @@ import type { FileIconCache } from '../FileIconCache/FileIconCache.ts'
 import type { FileIconsResult } from '../FileIconsRequest/FileIconsResult.ts'
 import * as GetFileIconsCached from '../GetFileIconsCached/GetFileIconsCached.ts'
 import * as GetMissingIconRequests from '../GetMissingIconRequests/GetMissingIconRequests.ts'
-import { getPaths } from '../GetPaths/GetPaths.ts'
 import * as RequestFileIcons from '../RequestFileIcons/RequestFileIcons.ts'
 import * as UpdateIconCache from '../UpdateIconCache/UpdateIconCache.ts'
 
@@ -11,8 +10,7 @@ export const getFileIcons = async (dirents: readonly ExplorerItem[], fileIconCac
   const missingRequests = GetMissingIconRequests.getMissingIconRequests(dirents, fileIconCache)
   const newIcons = await RequestFileIcons.requestFileIcons(missingRequests)
   const newFileIconCache = UpdateIconCache.updateIconCache(fileIconCache, missingRequests, newIcons)
-  const paths = getPaths(dirents)
-  const icons = GetFileIconsCached.getIconsCached(paths, newFileIconCache)
+  const icons = GetFileIconsCached.getIconsCached(dirents, newFileIconCache)
   return {
     icons,
     newFileIconCache,

--- a/packages/explorer-view/src/parts/GetFileIconsCached/GetFileIconsCached.ts
+++ b/packages/explorer-view/src/parts/GetFileIconsCached/GetFileIconsCached.ts
@@ -1,5 +1,10 @@
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 import type { FileIconCache } from '../FileIconCache/FileIconCache.ts'
+import * as GetIconCacheKey from '../GetIconCacheKey/GetIconCacheKey.ts'
 
-export const getIconsCached = (dirents: readonly string[], fileIconCache: FileIconCache): string[] => {
-  return dirents.map((dirent) => fileIconCache[dirent])
+export const getIconsCached = (dirents: readonly ExplorerItem[], fileIconCache: FileIconCache): string[] => {
+  return dirents.map((dirent) => {
+    const cacheKey = GetIconCacheKey.getIconCacheKey(dirent.path, dirent.type)
+    return fileIconCache[cacheKey]
+  })
 }

--- a/packages/explorer-view/src/parts/GetIconCacheKey/GetIconCacheKey.ts
+++ b/packages/explorer-view/src/parts/GetIconCacheKey/GetIconCacheKey.ts
@@ -1,0 +1,12 @@
+import * as DirentType from '../DirentType/DirentType.ts'
+
+export const getIconCacheKey = (path: string, type: number): string => {
+  switch (type) {
+    case DirentType.DirectoryExpanded:
+    case DirentType.DirectoryExpanding:
+    case DirentType.EditingDirectoryExpanded:
+      return `${path}#expanded`
+    default:
+      return path
+  }
+}

--- a/packages/explorer-view/src/parts/GetMissingIconRequests/GetMissingIconRequests.ts
+++ b/packages/explorer-view/src/parts/GetMissingIconRequests/GetMissingIconRequests.ts
@@ -1,11 +1,13 @@
 import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 import type { FileIconCache } from '../FileIconCache/FileIconCache.ts'
 import type { IconRequest } from '../IconRequest/IconRequest.ts'
+import * as GetIconCacheKey from '../GetIconCacheKey/GetIconCacheKey.ts'
 
 const getMissingDirents = (dirents: readonly ExplorerItem[], fileIconCache: FileIconCache): readonly ExplorerItem[] => {
   const missingDirents: ExplorerItem[] = []
   for (const dirent of dirents) {
-    if (!(dirent.path in fileIconCache)) {
+    const cacheKey = GetIconCacheKey.getIconCacheKey(dirent.path, dirent.type)
+    if (!(cacheKey in fileIconCache)) {
       missingDirents.push(dirent)
     }
   }
@@ -13,7 +15,9 @@ const getMissingDirents = (dirents: readonly ExplorerItem[], fileIconCache: File
 }
 
 const toIconRequest = (dirent: ExplorerItem): IconRequest => {
+  const cacheKey = GetIconCacheKey.getIconCacheKey(dirent.path, dirent.type)
   return {
+    ...(cacheKey !== dirent.path && { expanded: true }),
     name: dirent.name,
     path: dirent.path,
     type: dirent.type,

--- a/packages/explorer-view/src/parts/IconRequest/IconRequest.ts
+++ b/packages/explorer-view/src/parts/IconRequest/IconRequest.ts
@@ -1,4 +1,5 @@
 export interface IconRequest {
+  readonly expanded?: boolean
   readonly name: string
   readonly path: string
   readonly type: number

--- a/packages/explorer-view/src/parts/ToSimpleIconRequest/ToSimpleIconRequest.ts
+++ b/packages/explorer-view/src/parts/ToSimpleIconRequest/ToSimpleIconRequest.ts
@@ -3,6 +3,7 @@ import { getSimpleIconRequestType } from '../GetSimpleIconRequestType/GetSimpleI
 
 export const toSimpleIconRequest = (request: IconRequest): any => {
   return {
+    ...(request.expanded && { expanded: true }),
     name: request.name,
     type: getSimpleIconRequestType(request.type),
   }

--- a/packages/explorer-view/src/parts/UpdateIconCache/UpdateIconCache.ts
+++ b/packages/explorer-view/src/parts/UpdateIconCache/UpdateIconCache.ts
@@ -1,5 +1,6 @@
 import type { FileIconCache } from '../FileIconCache/FileIconCache.ts'
 import type { IconRequest } from '../IconRequest/IconRequest.ts'
+import * as GetIconCacheKey from '../GetIconCacheKey/GetIconCacheKey.ts'
 
 export const updateIconCache = (iconCache: FileIconCache, missingRequests: readonly IconRequest[], newIcons: readonly string[]): FileIconCache => {
   if (missingRequests.length === 0) {
@@ -9,7 +10,8 @@ export const updateIconCache = (iconCache: FileIconCache, missingRequests: reado
   for (let i = 0; i < missingRequests.length; i++) {
     const request = missingRequests[i]
     const icon = newIcons[i]
-    newFileIconCache[request.path] = icon
+    const cacheKey = GetIconCacheKey.getIconCacheKey(request.path, request.type)
+    newFileIconCache[cacheKey] = icon
   }
   return newFileIconCache
 }

--- a/packages/explorer-view/test/GetFileIcons.test.ts
+++ b/packages/explorer-view/test/GetFileIcons.test.ts
@@ -101,3 +101,29 @@ test('getFileIcons - mixed cache', async () => {
     ],
   ])
 })
+
+test('getFileIcons - expanded folder uses expanded request and cache entry', async () => {
+  const dirents: readonly ExplorerItem[] = [
+    { depth: 0, name: 'packages', path: '/packages', selected: false, type: DirentType.Directory },
+    { depth: 0, name: 'packages', path: '/packages', selected: false, type: DirentType.DirectoryExpanded },
+  ]
+  const cache: FileIconCache = {
+    '/packages': 'folder-packages',
+  }
+
+  using mockRpc = IconThemeWorker.registerMockRpc({
+    'IconTheme.getIcons'() {
+      return ['folder-packages-open']
+    },
+  })
+
+  const result = await GetFileIcons.getFileIcons(dirents, cache)
+  expect(result).toEqual({
+    icons: ['folder-packages', 'folder-packages-open'],
+    newFileIconCache: {
+      '/packages': 'folder-packages',
+      '/packages#expanded': 'folder-packages-open',
+    },
+  })
+  expect(mockRpc.invocations).toEqual([['IconTheme.getIcons', [{ expanded: true, name: 'packages', type: 2 }]]])
+})

--- a/packages/explorer-view/test/GetIconCacheKey.test.ts
+++ b/packages/explorer-view/test/GetIconCacheKey.test.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@jest/globals'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import * as GetIconCacheKey from '../src/parts/GetIconCacheKey/GetIconCacheKey.ts'
+
+test('getIconCacheKey - file', () => {
+  expect(GetIconCacheKey.getIconCacheKey('/workspace/file.txt', DirentType.File)).toBe('/workspace/file.txt')
+})
+
+test('getIconCacheKey - directory', () => {
+  expect(GetIconCacheKey.getIconCacheKey('/workspace/folder', DirentType.Directory)).toBe('/workspace/folder')
+})
+
+test('getIconCacheKey - expanded directory', () => {
+  expect(GetIconCacheKey.getIconCacheKey('/workspace/folder', DirentType.DirectoryExpanded)).toBe('/workspace/folder#expanded')
+})

--- a/packages/explorer-view/test/GetMissingIconRequests.test.ts
+++ b/packages/explorer-view/test/GetMissingIconRequests.test.ts
@@ -30,3 +30,15 @@ test('getMissingIconRequests - some missing', () => {
     { name: 'file2.txt', path: '/test/file2.txt', type: DirentType.File },
   ])
 })
+
+test('getMissingIconRequests - expanded folder cached separately', () => {
+  const dirents: readonly ExplorerItem[] = [
+    { depth: 0, name: 'packages', path: '/test/packages', selected: false, type: DirentType.DirectoryExpanded },
+  ]
+  const cache: FileIconCache = {
+    '/test/packages': 'folder-icon',
+  }
+  expect(GetMissingIconRequests.getMissingIconRequests(dirents, cache)).toEqual([
+    { expanded: true, name: 'packages', path: '/test/packages', type: DirentType.DirectoryExpanded },
+  ])
+})

--- a/packages/explorer-view/test/RequestFileIcons.test.ts
+++ b/packages/explorer-view/test/RequestFileIcons.test.ts
@@ -39,6 +39,20 @@ test('requestFileIcons - folder icons', async () => {
   expect(mockRpc.invocations).toEqual([['IconTheme.getIcons', [{ name: 'folder', type: 2 }]]])
 })
 
+test('requestFileIcons - expanded folder icons', async () => {
+  const requests = [{ expanded: true, name: 'folder', path: '/test/folder', type: DirentType.DirectoryExpanded }]
+
+  using mockRpc = IconThemeWorker.registerMockRpc({
+    'IconTheme.getIcons'() {
+      return ['folder-icon-open']
+    },
+  })
+
+  const result = await RequestFileIcons.requestFileIcons(requests)
+  expect(result).toEqual(['folder-icon-open'])
+  expect(mockRpc.invocations).toEqual([['IconTheme.getIcons', [{ expanded: true, name: 'folder', type: 2 }]]])
+})
+
 test('requestFileIcons - mixed requests', async () => {
   const requests = [
     { name: 'file.txt', path: '/test/file.txt', type: DirentType.File },

--- a/packages/explorer-view/test/UpdateIconCache.test.ts
+++ b/packages/explorer-view/test/UpdateIconCache.test.ts
@@ -31,3 +31,15 @@ test('updateIconCache - immutability', () => {
   expect(result).not.toBe(cache)
   expect(cache).toEqual({ existing: 'icon' })
 })
+
+test('updateIconCache - expanded folder', () => {
+  const cache: FileIconCache = {
+    '/test/packages': 'folder-icon',
+  }
+  const requests: readonly IconRequest[] = [{ expanded: true, name: 'packages', path: '/test/packages', type: DirentType.DirectoryExpanded }]
+  const newIcons: readonly string[] = ['folder-icon-open']
+  expect(UpdateIconCache.updateIconCache(cache, requests, newIcons)).toEqual({
+    '/test/packages': 'folder-icon',
+    '/test/packages#expanded': 'folder-icon-open',
+  })
+})


### PR DESCRIPTION
Updates explorer icon requests and caching so expanded folders use expanded folder icons when the icon theme provides them.