### PR TITLE
fix: disable explorer rename on readonly file systems

### DIFF
--- a/packages/explorer-view/src/parts/Create/Create.ts
+++ b/packages/explorer-view/src/parts/Create/Create.ts
@@ -58,6 +58,7 @@ export const create = (
     initial: true,
     inputSource: 0,
     isPointerDown: false,
+    isReadonly: false,
     itemHeight: Height.ListItem,
     items: [],
     maxIndent: 0,

--- a/packages/explorer-view/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/explorer-view/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -41,6 +41,7 @@ export const createDefaultState = (): ExplorerState => ({
   initial: false,
   inputSource: 0,
   isPointerDown: false,
+  isReadonly: false,
   itemHeight: 20,
   items: [],
   maxIndent: 0,

--- a/packages/explorer-view/src/parts/ExplorerState/ExplorerState.ts
+++ b/packages/explorer-view/src/parts/ExplorerState/ExplorerState.ts
@@ -44,6 +44,7 @@ export interface ExplorerState {
   readonly initial: boolean
   readonly inputSource: number
   readonly isPointerDown: boolean
+  readonly isReadonly: boolean
   readonly itemHeight: number
   readonly items: readonly ExplorerItem[]
   readonly maxIndent: number

--- a/packages/explorer-view/src/parts/FileSystem/FileSystem.ts
+++ b/packages/explorer-view/src/parts/FileSystem/FileSystem.ts
@@ -12,6 +12,10 @@ export const getPathSeparator = async (root: string): Promise<string> => {
   return FileSystemWorker.invoke('FileSystem.getPathSeparator', root)
 }
 
+export const isReadonly = async (root: string): Promise<boolean> => {
+  return FileSystemWorker.invoke('FileSystem.isReadonly', root)
+}
+
 export const getRealPath = async (path: string): Promise<string> => {
   return FileSystemWorker.invoke('FileSystem.getRealPath', path)
 }

--- a/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -90,6 +90,11 @@ const menuEntryRename: MenuEntry = {
   label: ViewletExplorerStrings.rename(),
 }
 
+const menuEntryRenameDisabled: MenuEntry = {
+  ...menuEntryRename,
+  flags: MenuItemFlags.Disabled,
+}
+
 const menuEntryDelete: MenuEntry = {
   command: 'Explorer.removeDirent',
   flags: MenuItemFlags.None,
@@ -104,23 +109,6 @@ const menuEntryRemoveFolderFromWorkspace: MenuEntry = {
   label: ViewletExplorerStrings.removeFolderFromWorkspace(),
 }
 
-const ALL_ENTRIES: readonly MenuEntry[] = [
-  menuEntryNewFile,
-  menuEntryNewFolder,
-  menuEntryOpenContainingFolder,
-  menuEntryOpenInIntegratedTerminal,
-  MenuEntrySeparator.menuEntrySeparator,
-  menuEntryCut,
-  menuEntryCopy,
-  menuEntryPaste,
-  MenuEntrySeparator.menuEntrySeparator,
-  menuEntryCopyPath,
-  menuEntryCopyRelativePath,
-  MenuEntrySeparator.menuEntrySeparator,
-  menuEntryRename,
-  menuEntryDelete,
-]
-
 // TODO there are two possible ways of getting the focused dirent of explorer
 // 1. directly access state of explorer (bad because it directly accesses state of another component)
 // 2. expose getFocusedDirent method in explorer (bad because explorer code should not know about for menuEntriesExplorer, which needs that method)
@@ -131,11 +119,33 @@ const getFocusedDirent = (explorerState: ExplorerState): ExplorerItem | undefine
   return explorerState.items[explorerState.focusedIndex]
 }
 
-const getMenuEntriesDirectory = (): readonly MenuEntry[] => {
-  return ALL_ENTRIES
+const getMenuEntryRename = (state: ExplorerState): MenuEntry => {
+  if (state.isReadonly) {
+    return menuEntryRenameDisabled
+  }
+  return menuEntryRename
 }
 
-const getMenuEntriesFile = (): readonly MenuEntry[] => {
+const getMenuEntriesDirectory = (state: ExplorerState): readonly MenuEntry[] => {
+  return [
+    menuEntryNewFile,
+    menuEntryNewFolder,
+    menuEntryOpenContainingFolder,
+    menuEntryOpenInIntegratedTerminal,
+    MenuEntrySeparator.menuEntrySeparator,
+    menuEntryCut,
+    menuEntryCopy,
+    menuEntryPaste,
+    MenuEntrySeparator.menuEntrySeparator,
+    menuEntryCopyPath,
+    menuEntryCopyRelativePath,
+    MenuEntrySeparator.menuEntrySeparator,
+    getMenuEntryRename(state),
+    menuEntryDelete,
+  ]
+}
+
+const getMenuEntriesFile = (state: ExplorerState): readonly MenuEntry[] => {
   return [
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
@@ -149,12 +159,12 @@ const getMenuEntriesFile = (): readonly MenuEntry[] => {
     MenuEntrySeparator.menuEntrySeparator,
     menuEntrySelectForCompare,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryRename,
+    getMenuEntryRename(state),
     menuEntryDelete,
   ]
 }
 
-const getMenuEntriesFileCompareWithSelected = (): readonly MenuEntry[] => {
+const getMenuEntriesFileCompareWithSelected = (state: ExplorerState): readonly MenuEntry[] => {
   return [
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
@@ -168,13 +178,13 @@ const getMenuEntriesFileCompareWithSelected = (): readonly MenuEntry[] => {
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCompareWithSelected,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryRename,
+    getMenuEntryRename(state),
     menuEntryDelete,
   ]
 }
 
-const getMenuEntriesDefault = (): readonly MenuEntry[] => {
-  return ALL_ENTRIES
+const getMenuEntriesDefault = (state: ExplorerState): readonly MenuEntry[] => {
+  return getMenuEntriesDirectory(state)
 }
 
 const getMenuEntriesRoot = (root: string): readonly MenuEntry[] => {
@@ -202,13 +212,13 @@ export const getMenuEntries = (state: ExplorerState): readonly MenuEntry[] => {
   }
   switch (focusedDirent.type) {
     case DirentType.Directory:
-      return getMenuEntriesDirectory()
+      return getMenuEntriesDirectory(state)
     case DirentType.File:
       if (state.compareSourceUri && state.compareSourceUri !== focusedDirent.path) {
-        return getMenuEntriesFileCompareWithSelected()
+        return getMenuEntriesFileCompareWithSelected(state)
       }
-      return getMenuEntriesFile()
+      return getMenuEntriesFile(state)
     default:
-      return getMenuEntriesDefault()
+      return getMenuEntriesDefault(state)
   }
 }

--- a/packages/explorer-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/explorer-view/src/parts/LoadContent/LoadContent.ts
@@ -1,4 +1,5 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as FileSystem from '../FileSystem/FileSystem.ts'
 import * as GetErrorCode from '../GetErrorCode/GetErrorCode.ts'
 import * as GetErrorMessage from '../GetErrorMessage/GetErrorMessage.ts'
 import * as GetExcluded from '../GetExcluded/GetExcluded.ts'
@@ -19,7 +20,10 @@ export const loadContent = async (state: ExplorerState, savedState: any): Promis
   const root = GetSavedRoot.getSavedRoot(savedState, workspacePath)
   try {
     // TODO path separator could be restored from saved state
-    const pathSeparator = await GetPathSeparator.getPathSeparator(root) // TODO only load path separator once
+    const [pathSeparator, isReadonly] = await Promise.all([
+      GetPathSeparator.getPathSeparator(root), // TODO only load path separator once
+      FileSystem.isReadonly(root),
+    ])
     const excluded = GetExcluded.getExcluded()
     const restoredDirents = await RestoreExpandedState.restoreExpandedState(savedState, root, pathSeparator, excluded)
     const rawDeltaY = GetRestoredDeltaY.getRestoredDeltaY(savedState)
@@ -46,6 +50,7 @@ export const loadContent = async (state: ExplorerState, savedState: any): Promis
       excluded,
       hasError: false,
       initial: false,
+      isReadonly,
       items: restoredDirents,
       maxIndent: 10,
       minLineY,
@@ -63,6 +68,7 @@ export const loadContent = async (state: ExplorerState, savedState: any): Promis
       errorMessage,
       hasError: true,
       initial: false,
+      isReadonly: false,
       items: [],
       root,
       useChevrons,

--- a/packages/explorer-view/src/parts/MenuItemFlags/MenuItemFlags.ts
+++ b/packages/explorer-view/src/parts/MenuItemFlags/MenuItemFlags.ts
@@ -2,4 +2,6 @@ export const Separator = 1
 
 export const None = 0
 
+export const Disabled = 5
+
 export const RestoreFocus = 6

--- a/packages/explorer-view/test/FileSystem.test.ts
+++ b/packages/explorer-view/test/FileSystem.test.ts
@@ -98,3 +98,15 @@ test('getPathSeparator', async () => {
   expect(result).toBe('/')
   expect(mockRpc.invocations).toEqual([['FileSystem.getPathSeparator', '/']])
 })
+
+test('isReadonly', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.isReadonly'() {
+      return true
+    },
+  })
+
+  const result = await FileSystem.isReadonly('/test')
+  expect(result).toBe(true)
+  expect(mockRpc.invocations).toEqual([['FileSystem.isReadonly', '/test']])
+})

--- a/packages/explorer-view/test/GetMenuEntries2.test.ts
+++ b/packages/explorer-view/test/GetMenuEntries2.test.ts
@@ -5,6 +5,7 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import { set } from '../src/parts/ExplorerStates/ExplorerStates.ts'
 import { getMenuEntries2 } from '../src/parts/GetMenuEntries2/GetMenuEntries2.ts'
+import * as MenuItemFlags from '../src/parts/MenuItemFlags/MenuItemFlags.ts'
 
 test('getMenuEntries2 - root', () => {
   const uid = 1
@@ -91,4 +92,28 @@ test('getMenuEntries2 - file shows compare with selected for different file', ()
   const menuEntries = getMenuEntries2(state)
   expect(menuEntries.some((entry) => entry.id === 'compareWithSelected')).toBe(true)
   expect(menuEntries.some((entry) => entry.id === 'selectForCompare')).toBe(false)
+})
+
+test('getMenuEntries2 - file disables rename when file system is readonly', () => {
+  const item: ExplorerItem = {
+    depth: 0,
+    name: 'test.txt',
+    path: '/test.txt',
+    selected: false,
+    type: DirentType.File,
+  }
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    isReadonly: true,
+    items: [item],
+  }
+  const menuEntries = getMenuEntries2(state)
+  const renameEntry = menuEntries.find((entry) => entry.id === 'rename')
+  expect(renameEntry).toEqual({
+    command: 'Explorer.renameDirent',
+    flags: MenuItemFlags.Disabled,
+    id: 'rename',
+    label: 'Rename',
+  })
 })

--- a/packages/explorer-view/test/HandleDropRootDefault.test.ts
+++ b/packages/explorer-view/test/HandleDropRootDefault.test.ts
@@ -10,6 +10,9 @@ test('handleDropRootDefault opens dropped folder as workspace when workspace is 
     'FileSystem.getPathSeparator'() {
       return '/'
     },
+    'FileSystem.isReadonly'() {
+      return false
+    },
     'FileSystem.readDirWithFileTypes'() {
       return [{ isDirectory: false, isFile: true, name: 'inside.txt' }]
     },
@@ -55,6 +58,7 @@ test('handleDropRootDefault opens dropped folder as workspace when workspace is 
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', 'html://dropped-folder'],
+    ['FileSystem.isReadonly', 'html://dropped-folder'],
     ['FileSystem.readDirWithFileTypes', 'html://dropped-folder'],
   ])
   expect(mockSourceControlRpc.invocations).toEqual([])
@@ -64,6 +68,9 @@ test('handleDropRootDefault opens first dropped folder as workspace when two fol
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return [{ isDirectory: false, isFile: true, name: 'inside.txt' }]
@@ -114,6 +121,7 @@ test('handleDropRootDefault opens first dropped folder as workspace when two fol
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', 'html://first-folder'],
+    ['FileSystem.isReadonly', 'html://first-folder'],
     ['FileSystem.readDirWithFileTypes', 'html://first-folder'],
   ])
   expect(mockSourceControlRpc.invocations).toEqual([])
@@ -143,6 +151,9 @@ test('handleDropRootDefault opens dropped folder as workspace when file and fold
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return [{ isDirectory: false, isFile: true, name: 'folder-inside.txt' }]
@@ -193,6 +204,7 @@ test('handleDropRootDefault opens dropped folder as workspace when file and fold
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', 'html://dropped-folder'],
+    ['FileSystem.isReadonly', 'html://dropped-folder'],
     ['FileSystem.readDirWithFileTypes', 'html://dropped-folder'],
   ])
   expect(mockSourceControlRpc.invocations).toEqual([])

--- a/packages/explorer-view/test/HandleDropRootElectron.test.ts
+++ b/packages/explorer-view/test/HandleDropRootElectron.test.ts
@@ -10,6 +10,9 @@ test('handleDropRootElectron opens dropped folder as workspace when workspace is
     'FileSystem.getPathSeparator'() {
       return '/'
     },
+    'FileSystem.isReadonly'() {
+      return false
+    },
     'FileSystem.readDirWithFileTypes'() {
       return [{ isDirectory: false, isFile: true, name: 'inside.txt' }]
     },
@@ -51,6 +54,7 @@ test('handleDropRootElectron opens dropped folder as workspace when workspace is
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', '/home/simon/dotfiles'],
+    ['FileSystem.isReadonly', '/home/simon/dotfiles'],
     ['FileSystem.readDirWithFileTypes', '/home/simon/dotfiles'],
   ])
   expect(mockSourceControlRpc.invocations).toEqual([])

--- a/packages/explorer-view/test/HandleWorkspaceChange.test.ts
+++ b/packages/explorer-view/test/HandleWorkspaceChange.test.ts
@@ -9,6 +9,9 @@ test('should update state with new workspace path and load content', async () =>
     'FileSystem.getPathSeparator'() {
       return '/'
     },
+    'FileSystem.isReadonly'() {
+      return false
+    },
     'FileSystem.readDirWithFileTypes'() {
       return []
     },
@@ -47,6 +50,7 @@ test('should update state with new workspace path and load content', async () =>
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', '/new/workspace/path'],
+    ['FileSystem.isReadonly', '/new/workspace/path'],
     ['FileSystem.readDirWithFileTypes', '/new/workspace/path'],
   ])
   expect(mockSourceControlRpc.invocations).toEqual([])
@@ -56,6 +60,9 @@ test('should preserve state properties when updating workspace', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return []
@@ -107,6 +114,7 @@ test('should preserve state properties when updating workspace', async () => {
       ['Preferences.get', 'explorer.sourceControlDecorations'],
       ['Workspace.getPath'],
       ['FileSystem.getPathSeparator', '/another/workspace'],
+      ['FileSystem.isReadonly', '/another/workspace'],
       ['FileSystem.readDirWithFileTypes', '/another/workspace'],
     ]),
   )
@@ -117,6 +125,9 @@ test('should handle workspace path change with existing content', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return [
@@ -154,6 +165,7 @@ test('should handle workspace path change with existing content', async () => {
       ['Preferences.get', 'explorer.sourceControlDecorations'],
       ['Workspace.getPath'],
       ['FileSystem.getPathSeparator', '/changed/workspace/path'],
+      ['FileSystem.isReadonly', '/changed/workspace/path'],
       ['FileSystem.readDirWithFileTypes', '/changed/workspace/path'],
     ]),
   )
@@ -164,6 +176,9 @@ test('should handle workspace path change with chevrons enabled', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return []
@@ -196,6 +211,7 @@ test('should handle workspace path change with chevrons enabled', async () => {
       ['Preferences.get', 'explorer.sourceControlDecorations'],
       ['Workspace.getPath'],
       ['FileSystem.getPathSeparator', '/chevron/workspace'],
+      ['FileSystem.isReadonly', '/chevron/workspace'],
       ['FileSystem.readDirWithFileTypes', '/chevron/workspace'],
     ]),
   )
@@ -206,6 +222,9 @@ test('should handle different path separators', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '\\'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       return []
@@ -238,6 +257,7 @@ test('should handle different path separators', async () => {
       ['Preferences.get', 'explorer.sourceControlDecorations'],
       ['Workspace.getPath'],
       ['FileSystem.getPathSeparator', 'C:\\windows\\workspace'],
+      ['FileSystem.isReadonly', 'C:\\windows\\workspace'],
       ['FileSystem.readDirWithFileTypes', 'C:\\windows\\workspace'],
     ]),
   )
@@ -248,6 +268,9 @@ test('should set load error state when reading folder fails', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return false
     },
     'FileSystem.readDirWithFileTypes'() {
       const error = Object.assign(new Error('Permission denied'), {
@@ -286,6 +309,7 @@ test('should set load error state when reading folder fails', async () => {
       ['Preferences.get', 'explorer.sourceControlDecorations'],
       ['Workspace.getPath'],
       ['FileSystem.getPathSeparator', '/restricted/workspace'],
+      ['FileSystem.isReadonly', '/restricted/workspace'],
       ['FileSystem.readDirWithFileTypes', '/restricted/workspace'],
     ]),
   )

--- a/packages/explorer-view/test/LoadContent.test.ts
+++ b/packages/explorer-view/test/LoadContent.test.ts
@@ -10,6 +10,9 @@ test('loadContent clamps restored deltaY to 0 when content is shorter after relo
     'FileSystem.getPathSeparator'() {
       return '/'
     },
+    'FileSystem.isReadonly'() {
+      return false
+    },
     'FileSystem.readDirWithFileTypes'() {
       return [
         { name: 'folder1', type: Directory },
@@ -67,6 +70,7 @@ test('loadContent clamps restored deltaY to 0 when content is shorter after relo
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', '/workspace'],
+    ['FileSystem.isReadonly', '/workspace'],
     ['FileSystem.readDirWithFileTypes', '/workspace'],
   ])
 })
@@ -75,6 +79,9 @@ test('loadContent clamps restored deltaY to maxDeltaY when content is still scro
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.getPathSeparator'() {
       return '/'
+    },
+    'FileSystem.isReadonly'() {
+      return true
     },
     'FileSystem.readDirWithFileTypes'() {
       return [
@@ -106,10 +113,12 @@ test('loadContent clamps restored deltaY to maxDeltaY when content is still scro
 
   expect({
     deltaY: result.deltaY,
+    isReadonly: result.isReadonly,
     items: result.items,
     minLineY: result.minLineY,
   }).toEqual({
     deltaY: 60,
+    isReadonly: true,
     items: [
       { depth: 1, icon: '', name: 'file1', path: '/workspace/file1', posInSet: 1, setSize: 8, type: File },
       { depth: 1, icon: '', name: 'file2', path: '/workspace/file2', posInSet: 2, setSize: 8, type: File },
@@ -129,6 +138,7 @@ test('loadContent clamps restored deltaY to maxDeltaY when content is still scro
     ['Preferences.get', 'explorer.sourceControlDecorations'],
     ['Workspace.getPath'],
     ['FileSystem.getPathSeparator', '/workspace'],
+    ['FileSystem.isReadonly', '/workspace'],
     ['FileSystem.readDirWithFileTypes', '/workspace'],
   ])
 })


### PR DESCRIPTION
Summary:\n- load readonly file-system capability into explorer state\n- keep Rename visible but disabled for readonly file systems