### PR TITLE
feature: add explorer typeahead focus

### DIFF
--- a/packages/e2e/src/viewlet.explorer-large-directory-typeahead-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-large-directory-typeahead-focus.ts
@@ -1,8 +1,28 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-large-directory-typeahead-focus'
-export const skip = 1
 
-export const test: Test = async () => {
-  // Deferred: Explorer.handleKeyDown typeahead does not currently focus matching rows in the e2e runner.
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/banana.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/berry.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/cherry.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  // act
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+
+  // assert
+  const banana = Locator('.TreeItem[aria-label="banana.txt"]')
+  await expect(banana).toHaveId('TreeItemActive')
+
+  // act
+  await Command.execute('Explorer.handleKeyDown', false, 'e')
+
+  // assert
+  const berry = Locator('.TreeItem[aria-label="berry.txt"]')
+  await expect(berry).toHaveId('TreeItemActive')
 }

--- a/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -11,6 +11,7 @@ export const HandleDrop = 6
 export const HandleEditingInput = 7
 export const HandleInputBlur = 8
 export const HandleInputClick = 9
+export const HandleKeyDown = 21
 export const HandleListBlur = 11
 export const HandleListFocus = 12
 export const HandlePointerDown = 14

--- a/packages/explorer-view/src/parts/FilterByFocusWord/FilterByFocusWord.ts
+++ b/packages/explorer-view/src/parts/FilterByFocusWord/FilterByFocusWord.ts
@@ -5,7 +5,7 @@ export const filterByFocusWord = (items: readonly string[], focusedIndex: number
 
   const matches: number[] = []
   for (let i = 0; i < items.length; i++) {
-    if (items[i].toLowerCase().includes(focusWord)) {
+    if (items[i].toLowerCase().startsWith(focusWord)) {
       matches.push(i)
     }
   }

--- a/packages/explorer-view/src/parts/HandleKeyDown/HandleKeyDown.ts
+++ b/packages/explorer-view/src/parts/HandleKeyDown/HandleKeyDown.ts
@@ -6,8 +6,11 @@ import { isAscii } from '../IsAscii/IsAscii.ts'
 
 const typeAheadTimeout: { value?: ReturnType<typeof setTimeout> } = {}
 
-export const handleKeyDown = (state: ExplorerState, key: string): ExplorerState => {
+export const handleKeyDown = (state: ExplorerState, defaultPrevented: boolean, key: string): ExplorerState => {
   const { focusedIndex, focusWord, focusWordTimeout, items } = state
+  if (defaultPrevented) {
+    return state
+  }
   if (focusWord && key === '') {
     return cancelTypeAhead(state)
   }

--- a/packages/explorer-view/src/parts/IsAscii/IsAscii.ts
+++ b/packages/explorer-view/src/parts/IsAscii/IsAscii.ts
@@ -1,4 +1,4 @@
-const RE_ASCII = /^[a-z]$/
+const RE_ASCII = /^[a-z]$/i
 
 export const isAscii = (key: string): boolean => {
   return RE_ASCII.test(key)

--- a/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -17,6 +17,10 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       params: ['handleBlur'],
     },
     {
+      name: DomEventListenersFunctions.HandleKeyDown,
+      params: ['handleKeyDown', EventExpression.DefaultPrevented, EventExpression.Key],
+    },
+    {
       name: DomEventListenersFunctions.HandleClick,
       params: [
         'handleClickAt',

--- a/packages/explorer-view/test/FilterByFocusWord.test.ts
+++ b/packages/explorer-view/test/FilterByFocusWord.test.ts
@@ -11,6 +11,11 @@ test('filterByFocusWord - no match', () => {
   expect(filterByFocusWord(items, -1, 'x')).toBe(-1)
 })
 
+test('filterByFocusWord - only matches from the start of the name', () => {
+  const items = ['apple', 'snap', 'banana']
+  expect(filterByFocusWord(items, -1, 'a')).toBe(0)
+})
+
 test('filterByFocusWord - cycle through matches', () => {
   const items = ['apple', 'banana', 'berry']
   // First match

--- a/packages/explorer-view/test/HandleKeyDown.test.ts
+++ b/packages/explorer-view/test/HandleKeyDown.test.ts
@@ -1,16 +1,22 @@
-import { expect, test } from '@jest/globals'
+import { afterEach, expect, jest, test } from '@jest/globals'
 import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleKeyDown } from '../src/parts/HandleKeyDown/HandleKeyDown.ts'
 
-test.skip('handleKeyDown - empty state', () => {
+jest.useFakeTimers()
+
+afterEach(() => {
+  jest.clearAllTimers()
+})
+
+test('handleKeyDown - empty state', () => {
   const state = createDefaultState()
-  const newState = handleKeyDown(state, 'a')
+  const newState = handleKeyDown(state, false, 'a')
   expect(newState.focusWord).toBe('a')
   expect(newState.focusedIndex).toBe(0)
 })
 
-test.skip('handleKeyDown - with items', () => {
+test('handleKeyDown - with items', () => {
   const state: ExplorerState = {
     ...createDefaultState(),
     items: [
@@ -19,12 +25,12 @@ test.skip('handleKeyDown - with items', () => {
       { depth: 0, name: 'cherry', path: '/cherry', selected: false, type: 0 },
     ],
   }
-  const newState = handleKeyDown(state, 'b')
+  const newState = handleKeyDown(state, false, 'b')
   expect(newState.focusWord).toBe('b')
   expect(newState.focusedIndex).toBe(1)
 })
 
-test.skip('handleKeyDown - no match', () => {
+test('handleKeyDown - no match', () => {
   const state: ExplorerState = {
     ...createDefaultState(),
     items: [
@@ -33,12 +39,12 @@ test.skip('handleKeyDown - no match', () => {
       { depth: 0, name: 'cherry', path: '/cherry', selected: false, type: 0 },
     ],
   }
-  const newState = handleKeyDown(state, 'x')
+  const newState = handleKeyDown(state, false, 'x')
   expect(newState.focusWord).toBe('x')
   expect(newState.focusedIndex).toBe(0)
 })
 
-test.skip('handleKeyDown - multiple characters', () => {
+test('handleKeyDown - multiple characters', () => {
   const state: ExplorerState = {
     ...createDefaultState(),
     items: [
@@ -47,8 +53,28 @@ test.skip('handleKeyDown - multiple characters', () => {
       { depth: 0, name: 'cherry', path: '/cherry', selected: false, type: 0 },
     ],
   }
-  let newState = handleKeyDown(state, 'b')
-  newState = handleKeyDown(newState, 'a')
+  let newState = handleKeyDown(state, false, 'b')
+  newState = handleKeyDown(newState, false, 'a')
   expect(newState.focusWord).toBe('ba')
+  expect(newState.focusedIndex).toBe(1)
+})
+
+test('handleKeyDown - ignores handled keybindings', () => {
+  const state = createDefaultState()
+  const newState = handleKeyDown(state, true, 'b')
+  expect(newState).toBe(state)
+})
+
+test('handleKeyDown - supports uppercase keys', () => {
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    items: [
+      { depth: 0, name: 'apple', path: '/apple', selected: false, type: 0 },
+      { depth: 0, name: 'banana', path: '/banana', selected: false, type: 0 },
+      { depth: 0, name: 'cherry', path: '/cherry', selected: false, type: 0 },
+    ],
+  }
+  const newState = handleKeyDown(state, false, 'B')
+  expect(newState.focusWord).toBe('b')
   expect(newState.focusedIndex).toBe(1)
 })

--- a/packages/explorer-view/test/IsAscii.test.ts
+++ b/packages/explorer-view/test/IsAscii.test.ts
@@ -7,8 +7,8 @@ test('isAscii - lowercase ascii', () => {
 })
 
 test('isAscii - uppercase ascii', () => {
-  expect(isAscii('A')).toBe(false)
-  expect(isAscii('Z')).toBe(false)
+  expect(isAscii('A')).toBe(true)
+  expect(isAscii('Z')).toBe(true)
 })
 
 test('isAscii - non-ascii', () => {

--- a/packages/explorer-view/test/RenderEventListeners.test.ts
+++ b/packages/explorer-view/test/RenderEventListeners.test.ts
@@ -4,4 +4,8 @@ import * as RenderEventListeners from '../src/parts/RenderEventListeners/RenderE
 test('renderEventListeners', () => {
   const eventListeners = RenderEventListeners.renderEventListeners()
   expect(eventListeners).toBeDefined()
+  expect(eventListeners).toContainEqual({
+    name: 21,
+    params: ['handleKeyDown', 'event.defaultPrevented', 'event.key'],
+  })
 })


### PR DESCRIPTION
Adds explorer typeahead focus so printable keydown input moves focus to matching file tree rows after existing keybindings have had first chance to handle the key.