### PR TITLE
feature: add explorer view title

### DIFF
--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -23,6 +23,7 @@ import * as GetKeyBindings from '../GetKeyBindings/GetKeyBindings.ts'
 import * as GetMenuEntries2 from '../GetMenuEntries2/GetMenuEntries2.ts'
 import * as GetMenuEntries from '../GetMenuEntries/GetMenuEntries.ts'
 import * as GetMouseActions from '../GetMouseActions/GetMouseActions.ts'
+import * as GetTitle from '../GetTitle/GetTitle.ts'
 import * as HandleArrowLeft from '../HandleArrowLeft/HandleArrowLeft.ts'
 import * as HandleArrowRight from '../HandleArrowRight/HandleArrowRight.ts'
 import * as HandleBlur from '../HandleBlur/HandleBlur.ts'
@@ -109,6 +110,7 @@ export const commandMap = {
   'Explorer.getMenuEntries': GetMenuEntries.getMenuEntries,
   'Explorer.getMenuEntries2': WrapCommand.wrapGetter(GetMenuEntries2.getMenuEntries2),
   'Explorer.getMouseActions': GetMouseActions.getMouseActions,
+  'Explorer.getTitle': WrapCommand.wrapGetter(GetTitle.getTitle),
   'Explorer.handleArrowLeft': WrapCommand.wrapListItemCommand(HandleArrowLeft.handleArrowLeft),
   'Explorer.handleArrowRight': WrapCommand.wrapListItemCommand(HandleArrowRight.handleArrowRight),
   'Explorer.handleBlur': WrapCommand.wrapListItemCommand(HandleBlur.handleBlur),

--- a/packages/explorer-view/src/parts/GetTitle/GetTitle.ts
+++ b/packages/explorer-view/src/parts/GetTitle/GetTitle.ts
@@ -1,0 +1,11 @@
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as Path from '../Path/Path.ts'
+
+export const getTitle = (state: ExplorerState): string => {
+  const { pathSeparator, root } = state
+  if (!root) {
+    return 'Explorer'
+  }
+  const normalizedRoot = root.endsWith(pathSeparator) && root !== pathSeparator ? root.slice(0, -pathSeparator.length) : root
+  return Path.getBaseName(pathSeparator, normalizedRoot) || normalizedRoot
+}

--- a/packages/explorer-view/test/GetTitle.test.ts
+++ b/packages/explorer-view/test/GetTitle.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as GetTitle from '../src/parts/GetTitle/GetTitle.ts'
+
+test('getTitle - returns workspace name', () => {
+  const state = {
+    ...createDefaultState(),
+    root: '/home/test/project',
+  }
+
+  expect(GetTitle.getTitle(state)).toBe('project')
+})
+
+test('getTitle - returns explorer when no folder is open', () => {
+  const state = {
+    ...createDefaultState(),
+    root: '',
+  }
+
+  expect(GetTitle.getTitle(state)).toBe('Explorer')
+})
+
+test('getTitle - ignores trailing separator', () => {
+  const state = {
+    ...createDefaultState(),
+    root: '/home/test/project/',
+  }
+
+  expect(GetTitle.getTitle(state)).toBe('project')
+})
+
+test('getTitle - uses full root when path has no basename', () => {
+  const state = {
+    ...createDefaultState(),
+    root: '/',
+  }
+
+  expect(GetTitle.getTitle(state)).toBe('/')
+})


### PR DESCRIPTION
Adds an Explorer.getTitle command so the explorer view can expose the current workspace name for sidebar title rendering.