### PR TITLE
fix: show top-level new folder input first

### DIFF
--- a/packages/e2e/src/viewlet.explorer-toolbar-new-folder-button.ts
+++ b/packages/e2e/src/viewlet.explorer-toolbar-new-folder-button.ts
@@ -10,6 +10,16 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // act
   await Explorer.newFolder()
+
+  // assert
+  const firstTreeItem = Locator('.TreeItem').nth(0)
+  const inputBox = firstTreeItem.locator('input')
+  const folderIcon = firstTreeItem.locator('.FileIcon')
+  await expect(inputBox).toBeVisible()
+  await expect(inputBox).toBeFocused()
+  await expect(folderIcon).toBeVisible()
+
+  // act
   await Explorer.updateEditingValue('my-folder')
   await Explorer.acceptEdit()
 

--- a/packages/explorer-view/src/parts/GetNewDirentsForNewDirent/GetNewDirentsForNewDirent.ts
+++ b/packages/explorer-view/src/parts/GetNewDirentsForNewDirent/GetNewDirentsForNewDirent.ts
@@ -19,6 +19,9 @@ export const getNewDirentsForNewDirent = async (
       setSize: 1,
       type,
     }
+    if (type === DirentType.EditingFolder) {
+      return [newDirent, ...items]
+    }
     return [...items, newDirent]
   }
 

--- a/packages/explorer-view/src/parts/NewDirent/NewDirent.ts
+++ b/packages/explorer-view/src/parts/NewDirent/NewDirent.ts
@@ -5,7 +5,7 @@ import * as GetFittingIndex from '../GetFittingIndex/GetFittingIndex.ts'
 import * as GetNewDirentsForNewDirent from '../GetNewDirentsForNewDirent/GetNewDirentsForNewDirent.ts'
 import * as GetNewDirentType from '../GetNewDirentType/GetNewDirentType.ts'
 
-export const newDirent = async (state: ExplorerState, editingType: number): Promise<ExplorerState> => {
+export const newDirent = async (state: ExplorerState, editingType: number, editingIcon = ''): Promise<ExplorerState> => {
   // TODO do it like vscode, select position between folders and files
   const { editingIndex, focusedIndex, items, root } = state
   if (editingIndex !== -1) {
@@ -17,6 +17,7 @@ export const newDirent = async (state: ExplorerState, editingType: number): Prom
   const newEditingIndex = newDirents.findIndex((item) => item.type === DirentType.EditingFile || item.type === DirentType.EditingFolder)
   return {
     ...state,
+    editingIcon,
     editingIndex: newEditingIndex,
     editingType,
     editingValue: '',

--- a/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
+++ b/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
@@ -1,7 +1,12 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType.ts'
+import { getEditingIcon } from '../GetEditingIcon/GetEditingIcon.ts'
 import * as NewDirent from '../NewDirent/NewDirent.ts'
 
-export const newFolder = (state: ExplorerState): Promise<ExplorerState> => {
-  return NewDirent.newDirent(state, ExplorerEditingType.CreateFolder)
+export const newFolder = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.editingIndex !== -1) {
+    return state
+  }
+  const editingIcon = await getEditingIcon(ExplorerEditingType.CreateFolder, '')
+  return NewDirent.newDirent(state, ExplorerEditingType.CreateFolder, editingIcon)
 }

--- a/packages/explorer-view/test/GetNewDirentsForNewDirent.test.ts
+++ b/packages/explorer-view/test/GetNewDirentsForNewDirent.test.ts
@@ -236,3 +236,56 @@ test('getNewDirentsForNewDirent - focusedIndex -1 with existing items', async ()
   ])
   expect(mockRpc.invocations).toEqual([])
 })
+
+test('getNewDirentsForNewDirent - top-level new folder is inserted first', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readDirWithFileTypes'() {
+      return []
+    },
+  })
+
+  const defaultState = createDefaultState()
+  const state: ExplorerState = {
+    ...defaultState,
+    focusedIndex: -1,
+    items: [
+      {
+        depth: 0,
+        icon: '',
+        name: 'file1.txt',
+        path: '/root/file1.txt',
+        posInSet: 1,
+        selected: false,
+        setSize: 1,
+        type: DirentType.File,
+      },
+    ],
+  }
+  const root = '/root'
+
+  const result = await getNewDirentsForNewDirent(state.items, state.focusedIndex, DirentType.EditingFolder, root)
+
+  expect(result).toEqual([
+    {
+      depth: 0,
+      icon: '',
+      name: '',
+      path: '/root',
+      posInSet: 1,
+      selected: false,
+      setSize: 1,
+      type: DirentType.EditingFolder,
+    },
+    {
+      depth: 0,
+      icon: '',
+      name: 'file1.txt',
+      path: '/root/file1.txt',
+      posInSet: 1,
+      selected: false,
+      setSize: 1,
+      type: DirentType.File,
+    },
+  ])
+  expect(mockRpc.invocations).toEqual([])
+})

--- a/packages/explorer-view/test/HandleButtonClick.test.ts
+++ b/packages/explorer-view/test/HandleButtonClick.test.ts
@@ -47,6 +47,9 @@ test('handleButtonClick - NewFolder', async () => {
     'FileSystem.readDirWithFileTypes'() {
       return []
     },
+    'IconTheme.getFolderIcon'() {
+      return 'folder-icon'
+    },
   })
 
   const state: ExplorerState = {
@@ -56,6 +59,7 @@ test('handleButtonClick - NewFolder', async () => {
   }
   const newState = await handleButtonClick(state, InputName.NewFolder)
   expect(newState.editingType).toBe(ExplorerEditingType.CreateFolder)
+  expect(newState.editingIcon).toBe('folder-icon')
   expect(newState.editingIndex).toBeGreaterThanOrEqual(0)
   expect(newState.editingValue).toBe('')
 })

--- a/packages/explorer-view/test/NewFolder.test.ts
+++ b/packages/explorer-view/test/NewFolder.test.ts
@@ -17,7 +17,7 @@ test('newFolder', async () => {
       return undefined
     },
     'IconTheme.getFolderIcon'() {
-      return ''
+      return 'folder-icon'
     },
     'IconTheme.getIcons'() {
       return ['']
@@ -38,6 +38,7 @@ test('newFolder', async () => {
   const result = await newFolder(mockState)
   expect(result).toEqual({
     ...mockState,
+    editingIcon: 'folder-icon',
     editingIndex: 0,
     editingType: ExplorerEditingType.CreateFolder,
     editingValue: '',
@@ -56,5 +57,5 @@ test('newFolder', async () => {
       },
     ],
   })
-  expect(mockRpc.invocations).toEqual([])
+  expect(mockRpc.invocations).toEqual([['IconTheme.getFolderIcon', { name: '' }]])
 })


### PR DESCRIPTION
Summary:
- place the top-level new folder input before existing root items
- show the folder icon immediately for the new folder input
- add unit and e2e coverage for the regression