### PR TITLE
feature: support explorer shift range selection

### DIFF
--- a/packages/e2e/src/viewlet.explorer-select-multiple-files-with-mouse.ts
+++ b/packages/e2e/src/viewlet.explorer-select-multiple-files-with-mouse.ts
@@ -18,7 +18,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   const file1 = Locator('.TreeItem').nth(0)
   await expect(file1).toHaveClass('TreeItemActive')
   const file2 = Locator('.TreeItem').nth(1)
-  await expect(file2).toHaveClass('TreeItem')
+  await expect(file2).toHaveClass('TreeItemActive')
   const file3 = Locator('.TreeItem').nth(2)
-  await expect(file3).not.toHaveClass('TreeItemActive')
+  await expect(file3).toHaveClass('TreeItemActive')
 }

--- a/packages/e2e/src/viewlet.explorer-shift-select-different-nesting-levels.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-different-nesting-levels.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-different-nesting-levels'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/outer/inner`)
+  await FileSystem.writeFile(`${tmpDir}/outer/inner/deep.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/z.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.handleClick(0)
+  await Explorer.handleClick(1)
+
+  await Explorer.focusIndex(1)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 125)
+
+  for (const name of ['inner', 'deep.txt', 'z.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-files-backward.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-files-backward.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-files-backward'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/d.txt`, '')
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(3)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 65)
+
+  for (const name of ['a.txt', 'b.txt', 'c.txt', 'd.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-files-forward.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-files-forward.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-files-forward'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/d.txt`, '')
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(0)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 125)
+
+  for (const name of ['a.txt', 'b.txt', 'c.txt', 'd.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-folders.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-folders'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/a`)
+  await FileSystem.mkdir(`${tmpDir}/b`)
+  await FileSystem.mkdir(`${tmpDir}/c`)
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(0)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 105)
+
+  for (const name of ['a', 'b', 'c']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-mixed-files-and-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-mixed-files-and-folders.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-mixed-files-and-folders'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/a-folder`)
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(0)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 105)
+
+  for (const name of ['a-folder', 'b.txt', 'c.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-nested-files.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-nested-files.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-nested-files'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/folder/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/z.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.handleClick(0)
+
+  await Explorer.focusIndex(1)
+  await Explorer.handleClickAt(false, 0, false, true, 300, 125)
+
+  for (const name of ['a.txt', 'b.txt', 'z.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-while-creating-file.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-while-creating-file.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-while-creating-file'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.newFile()
+
+  await Explorer.handleClickAt(false, 0, false, true, 300, 65)
+
+  const input = Locator('.Explorer input')
+  await expect(input).toBeVisible()
+  for (const name of ['a.txt', 'b.txt', 'c.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-while-creating-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-while-creating-folder.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-while-creating-folder'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.newFolder()
+
+  await Explorer.handleClickAt(false, 0, false, true, 300, 125)
+
+  const input = Locator('.Explorer input')
+  await expect(input).toBeVisible()
+  for (const name of ['a.txt', 'b.txt', 'c.txt']) {
+    const item = Locator(`.TreeItem[aria-label="${name}"]`)
+    await expect(item).toHaveClass('TreeItemActive')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-shift-select-while-renaming.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-select-while-renaming.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-shift-select-while-renaming'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(1)
+  await Explorer.renameDirent()
+
+  await Explorer.handleClickAt(false, 0, false, true, 300, 105)
+
+  const input = Locator('.Explorer input')
+  const b = Locator('.TreeItem[aria-label="b.txt"]')
+  const c = Locator('.TreeItem[aria-label="c.txt"]')
+  await expect(input).toBeVisible()
+  await expect(b).toHaveClass('TreeItemActive')
+  await expect(c).toHaveClass('TreeItemActive')
+}

--- a/packages/explorer-view/src/parts/HandleClickAtRangeSelection/HandleClickAtRangeSelection.ts
+++ b/packages/explorer-view/src/parts/HandleClickAtRangeSelection/HandleClickAtRangeSelection.ts
@@ -4,7 +4,10 @@ import * as HandleRangeSelection from '../HandleRangeSelection/HandleRangeSelect
 export const handleClickAtRangeSelection = async (state: ExplorerState, index: number): Promise<ExplorerState> => {
   const { focusedIndex, items } = state
   const firstSelectedIndex = items.findIndex((item) => item.selected)
-  const anchorIndex = firstSelectedIndex === -1 ? (focusedIndex === -1 ? index : focusedIndex) : firstSelectedIndex
+  let anchorIndex = firstSelectedIndex
+  if (anchorIndex === -1) {
+    anchorIndex = focusedIndex === -1 ? index : focusedIndex
+  }
   const min = Math.min(anchorIndex, index)
   const max = Math.max(anchorIndex, index)
   const newState = HandleRangeSelection.handleRangeSelection(state, min, max)

--- a/packages/explorer-view/src/parts/HandleClickAtRangeSelection/HandleClickAtRangeSelection.ts
+++ b/packages/explorer-view/src/parts/HandleClickAtRangeSelection/HandleClickAtRangeSelection.ts
@@ -2,12 +2,14 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as HandleRangeSelection from '../HandleRangeSelection/HandleRangeSelection.ts'
 
 export const handleClickAtRangeSelection = async (state: ExplorerState, index: number): Promise<ExplorerState> => {
-  const { items } = state
+  const { focusedIndex, items } = state
   const firstSelectedIndex = items.findIndex((item) => item.selected)
-  if (firstSelectedIndex === -1) {
-    return HandleRangeSelection.handleRangeSelection(state, index, index)
+  const anchorIndex = firstSelectedIndex === -1 ? (focusedIndex === -1 ? index : focusedIndex) : firstSelectedIndex
+  const min = Math.min(anchorIndex, index)
+  const max = Math.max(anchorIndex, index)
+  const newState = HandleRangeSelection.handleRangeSelection(state, min, max)
+  return {
+    ...newState,
+    focusedIndex: index,
   }
-  const min = Math.min(firstSelectedIndex, index)
-  const max = Math.min(firstSelectedIndex, index)
-  return HandleRangeSelection.handleRangeSelection(state, min, max)
 }

--- a/packages/explorer-view/test/HandleClickAt.test.ts
+++ b/packages/explorer-view/test/HandleClickAt.test.ts
@@ -16,7 +16,7 @@ test.skip('handleClickAt - left click without shift', async () => {
   expect(result).toBeDefined()
 })
 
-test.skip('handleClickAt - shift click with no selection', async () => {
+test('handleClickAt - shift click with no selection uses focused item as anchor', async () => {
   const state: ExplorerState = {
     ...createDefaultState(),
     items: [
@@ -24,11 +24,12 @@ test.skip('handleClickAt - shift click with no selection', async () => {
       { depth: 1, name: 'b', path: '/b', selected: false, type: 0 },
     ],
   }
-  const result = await handleClickAt(state, false, LeftClick, false, true, 0, 0)
-  expect(result).toBeDefined()
+  const result = await handleClickAt({ ...state, focusedIndex: 1, itemHeight: 20, maxLineY: 2 }, false, LeftClick, false, true, 0, 0)
+  expect(result.items.map((item) => item.selected)).toEqual([true, true])
+  expect(result.focusedIndex).toBe(0)
 })
 
-test('handleClickAt - shift click with existing selection', async () => {
+test('handleClickAt - shift click with existing selection selects the complete range', async () => {
   const state: ExplorerState = {
     ...createDefaultState(),
     items: [
@@ -37,8 +38,9 @@ test('handleClickAt - shift click with existing selection', async () => {
       { depth: 1, name: 'c', path: '/c', selected: false, type: 0 },
     ],
   }
-  const result = await handleClickAt(state, false, LeftClick, false, true, 0, 0)
-  expect(result).toBeDefined()
+  const result = await handleClickAt({ ...state, itemHeight: 20, maxLineY: 3 }, false, LeftClick, false, true, 0, 40)
+  expect(result.items.map((item) => item.selected)).toEqual([true, true, true])
+  expect(result.focusedIndex).toBe(2)
 })
 
 test('handleClickAt - non left click', async () => {
@@ -54,30 +56,5 @@ test('handleClickAt - left click', async () => {
   const shiftKey = false
   const ctrlKey = false
   const result = await handleClickAt(state, false, LeftClick, ctrlKey, shiftKey, 0, 0)
-  expect(result).toBeDefined()
-})
-
-test.skip('handleClickAt - shift click with no selection', async () => {
-  const state: ExplorerState = {
-    ...createDefaultState(),
-    items: [
-      { depth: 1, name: 'a', path: '/a', selected: false, type: 0 },
-      { depth: 1, name: 'b', path: '/b', selected: false, type: 0 },
-    ],
-  }
-  const result = await handleClickAt(state, false, LeftClick, false, true, 0, 0)
-  expect(result).toBeDefined()
-})
-
-test('handleClickAt - shift click with existing selection', async () => {
-  const state: ExplorerState = {
-    ...createDefaultState(),
-    items: [
-      { depth: 1, name: 'a', path: '/a', selected: true, type: 0 },
-      { depth: 1, name: 'b', path: '/b', selected: false, type: 0 },
-      { depth: 1, name: 'c', path: '/c', selected: false, type: 0 },
-    ],
-  }
-  const result = await handleClickAt(state, false, LeftClick, false, true, 0, 0)
   expect(result).toBeDefined()
 })

--- a/packages/explorer-view/test/HandleClickAtRangeSelection.test.ts
+++ b/packages/explorer-view/test/HandleClickAtRangeSelection.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@jest/globals'
+import type { ExplorerItem } from '../src/parts/ExplorerItem/ExplorerItem.ts'
+import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleClickAtRangeSelection } from '../src/parts/HandleClickAtRangeSelection/HandleClickAtRangeSelection.ts'
+
+const createItem = (name: string, selected = false): ExplorerItem => ({
+  depth: 1,
+  name,
+  path: `/${name}`,
+  selected,
+  type: 0,
+})
+
+const createState = (focusedIndex: number, selectedIndices: readonly number[] = []): ExplorerState => ({
+  ...createDefaultState(),
+  focusedIndex,
+  items: ['a', 'b', 'c', 'd', 'e'].map((name, index) => createItem(name, selectedIndices.includes(index))),
+})
+
+const getSelectedIndices = (state: ExplorerState): readonly number[] => state.items.flatMap((item, index) => (item.selected ? [index] : []))
+
+test('selects forward from the focused item when no multi-selection exists', async () => {
+  const newState = await handleClickAtRangeSelection(createState(1), 4)
+
+  expect(getSelectedIndices(newState)).toEqual([1, 2, 3, 4])
+  expect(newState.focusedIndex).toBe(4)
+})
+
+test('selects backward from the focused item when no multi-selection exists', async () => {
+  const newState = await handleClickAtRangeSelection(createState(3), 0)
+
+  expect(getSelectedIndices(newState)).toEqual([0, 1, 2, 3])
+  expect(newState.focusedIndex).toBe(0)
+})
+
+test('uses the first selected item as the range anchor', async () => {
+  const newState = await handleClickAtRangeSelection(createState(4, [1]), 3)
+
+  expect(getSelectedIndices(newState)).toEqual([1, 2, 3])
+})
+
+test('keeps selections outside the new range', async () => {
+  const newState = await handleClickAtRangeSelection(createState(4, [1, 4]), 2)
+
+  expect(getSelectedIndices(newState)).toEqual([1, 2, 4])
+})
+
+test('selects only the clicked item when it is the anchor', async () => {
+  const newState = await handleClickAtRangeSelection(createState(2), 2)
+
+  expect(getSelectedIndices(newState)).toEqual([2])
+  expect(newState.focusedIndex).toBe(2)
+})
+
+test('selects only the clicked item when there is no anchor', async () => {
+  const newState = await handleClickAtRangeSelection(createState(-1), 3)
+
+  expect(getSelectedIndices(newState)).toEqual([3])
+  expect(newState.focusedIndex).toBe(3)
+})


### PR DESCRIPTION
Adds Shift-click range selection between the first selected or focused Explorer item and the clicked item. Covers files, folders, mixed and nested trees, both selection directions, and active rename/create inputs with focused unit and e2e regressions.