### PR TITLE
fix: preserve explorer order when revealing collapsed item

### DIFF
--- a/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-reveal-collapsed-folder-preserves-order'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const nestedFilePath = `${tmpDir}/a/b/c.txt`
@@ -10,21 +10,23 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await FileSystem.writeFile(nestedFilePath, 'content')
   await FileSystem.writeFile(`${tmpDir}/z.txt`, 'content')
   await Workspace.setPath(tmpDir)
-  const treeItems = Locator('.TreeItem')
-  await expect(treeItems).toHaveCount(2)
-  const folderA = treeItems.nth(0)
-  const folderB = treeItems.nth(1)
-  const nestedFile = treeItems.nth(2)
-  const rootFile = treeItems.nth(3)
+  const folderA = Locator('.TreeItem[aria-label="a"]')
+  const folderB = Locator('.TreeItem[aria-label="b"]')
+  const nestedFile = Locator('.TreeItem[aria-label="c.txt"]')
+  const rootFile = Locator('.TreeItem[aria-label="z.txt"]')
+  await expect(folderA).toBeVisible()
+  await expect(folderB).toBeHidden()
+  await expect(nestedFile).toBeHidden()
+  await expect(rootFile).toBeVisible()
 
   // act
   await Command.execute('Explorer.reveal', nestedFilePath)
 
   // assert
-  await expect(treeItems).toHaveCount(4)
-  await expect(folderA).toHaveText('a')
-  await expect(folderB).toHaveText('b')
-  await expect(nestedFile).toHaveText('c.txt')
+  await expect(folderA).toBeVisible()
+  await expect(folderB).toBeVisible()
+  await expect(nestedFile).toBeVisible()
   await expect(nestedFile).toHaveId('TreeItemActive')
-  await expect(rootFile).toHaveText('z.txt')
+  await Explorer.focusIndex(3)
+  await expect(rootFile).toHaveId('TreeItemActive')
 }

--- a/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
@@ -14,18 +14,21 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   const folderB = Locator('.TreeItem[aria-label="b"]')
   const nestedFile = Locator('.TreeItem[aria-label="c.txt"]')
   const rootFile = Locator('.TreeItem[aria-label="z.txt"]')
-  await expect(folderA).toBeVisible()
+  await Explorer.focusIndex(0)
+  await expect(folderA).toHaveId('TreeItemActive')
   await expect(folderB).toBeHidden()
   await expect(nestedFile).toBeHidden()
-  await expect(rootFile).toBeVisible()
 
   // act
   await Command.execute('Explorer.reveal', nestedFilePath)
 
   // assert
-  await expect(folderA).toBeVisible()
-  await expect(folderB).toBeVisible()
-  await expect(nestedFile).toBeVisible()
+  await expect(nestedFile).toHaveId('TreeItemActive')
+  await Explorer.focusIndex(0)
+  await expect(folderA).toHaveId('TreeItemActive')
+  await Explorer.focusIndex(1)
+  await expect(folderB).toHaveId('TreeItemActive')
+  await Explorer.focusIndex(2)
   await expect(nestedFile).toHaveId('TreeItemActive')
   await Explorer.focusIndex(3)
   await expect(rootFile).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
@@ -1,0 +1,30 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-reveal-collapsed-folder-preserves-order'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  const nestedFilePath = `${tmpDir}/a/b/c.txt`
+  await FileSystem.mkdir(`${tmpDir}/a/b`)
+  await FileSystem.writeFile(nestedFilePath, 'content')
+  await FileSystem.writeFile(`${tmpDir}/z.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  const treeItems = Locator('.TreeItem')
+  await expect(treeItems).toHaveCount(2)
+  const folderA = treeItems.nth(0)
+  const folderB = treeItems.nth(1)
+  const nestedFile = treeItems.nth(2)
+  const rootFile = treeItems.nth(3)
+
+  // act
+  await Command.execute('Explorer.reveal', nestedFilePath)
+
+  // assert
+  await expect(treeItems).toHaveCount(4)
+  await expect(folderA).toHaveText('a')
+  await expect(folderB).toHaveText('b')
+  await expect(nestedFile).toHaveText('c.txt')
+  await expect(nestedFile).toHaveId('TreeItemActive')
+  await expect(rootFile).toHaveText('z.txt')
+}

--- a/packages/explorer-view/src/parts/RevealItemHidden/RevealItemHidden.ts
+++ b/packages/explorer-view/src/parts/RevealItemHidden/RevealItemHidden.ts
@@ -20,8 +20,9 @@ export const revealItemHidden = async (state: ExplorerState, uri: string): Promi
   const pathPartsChildrenFlat = pathPartsChildren.flat()
   const orderedPathParts = orderDirents(pathPartsChildrenFlat)
   const mergedDirents = mergeVisibleWithHiddenItems(items, orderedPathParts)
+  const orderedDirents = orderDirents(mergedDirents)
   const expandedPaths = new Set(pathPartsToReveal.map((pathPart) => pathPart.path))
-  const newDirents = mergedDirents.map((item) => {
+  const newDirents = orderedDirents.map((item) => {
     if (expandedPaths.has(item.path) && item.type === DirentType.Directory) {
       return {
         ...item,

--- a/packages/explorer-view/test/RevealItemHidden.test.ts
+++ b/packages/explorer-view/test/RevealItemHidden.test.ts
@@ -63,6 +63,52 @@ test('revealItemHidden - expands visible ancestor folder', async () => {
   expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/root/folder1']])
 })
 
+test('revealItemHidden - inserts revealed descendants before the next visible sibling', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readDirWithFileTypes'(path: string) {
+      if (path === '/root/folder1') {
+        return [{ name: 'nested', type: DirentType.Directory }]
+      }
+      if (path === '/root/folder1/nested') {
+        return [{ name: 'file1.txt', type: DirentType.File }]
+      }
+      return []
+    },
+  })
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    items: [
+      {
+        depth: 1,
+        name: 'folder1',
+        path: '/root/folder1',
+        selected: false,
+        type: DirentType.Directory,
+      },
+      {
+        depth: 1,
+        name: 'sibling.txt',
+        path: '/root/sibling.txt',
+        selected: false,
+        type: DirentType.File,
+      },
+    ],
+    root: '/root',
+  }
+  const newState = await revealItemHidden(state, '/root/folder1/nested/file1.txt')
+  expect(newState.items.map((item) => item.path)).toEqual([
+    '/root/folder1',
+    '/root/folder1/nested',
+    '/root/folder1/nested/file1.txt',
+    '/root/sibling.txt',
+  ])
+  expect(newState.focusedIndex).toBe(2)
+  expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/root/folder1'],
+    ['FileSystem.readDirWithFileTypes', '/root/folder1/nested'],
+  ])
+})
+
 test('revealItemHidden - returns same state for empty path parts', async () => {
   using mockRpc = RendererWorker.registerMockRpc({})
   const state = createDefaultState()


### PR DESCRIPTION
Fix revealing an item beneath a collapsed folder so newly loaded descendants stay directly below their parent instead of being appended after root-level siblings.

Add unit and e2e regressions covering a collapsed nested file with a following root sibling.