### PR TITLE
feature: reuse page for e2e tests

### DIFF
--- a/packages/build/src/build-static.ts
+++ b/packages/build/src/build-static.ts
@@ -27,9 +27,9 @@ const content = await readFile(rendererWorkerPath, 'utf8')
 const workerPath = join(root, '.tmp/dist/dist/explorerViewWorkerMain.js')
 const remoteUrl = getRemoteUrl(workerPath)
 
-const occurrence = `// const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`
-const explorerWorkerUrl = \`${remoteUrl}\``
-const replacement = `const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\``
+const occurrence = `// const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`;
+const explorerWorkerUrl = \`${remoteUrl}\`;`
+const replacement = `const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`;`
 if (!content.includes(occurrence)) {
   throw new Error('occurrence not found')
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --resuse-page",
-    "e2e:firefox": "npm run patch:playwright-firefox-worker-websocket && node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --browser=firefox --resuse-page",
-    "e2e:firefox:headless": "npm run patch:playwright-firefox-worker-websocket && node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --browser=firefox --headless --resuse-page",
-    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --headless --resuse-page",
+    "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --reuse-page",
+    "e2e:firefox": "npm run patch:playwright-firefox-worker-websocket && node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --browser=firefox --reuse-page",
+    "e2e:firefox:headless": "npm run patch:playwright-firefox-worker-websocket && node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --browser=firefox --headless --reuse-page",
+    "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --only-extension=. --test-path=. --headless --reuse-page",
     "patch:playwright-firefox-worker-websocket": "node ./scripts/patch-playwright-firefox-worker-websocket.js",
     "type-check": "tsc"
   },

--- a/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied-escape-then-create-again.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied-escape-then-create-again.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-error-permission-denied-escape-then-create-again'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-create-file-error-permission-denied')

--- a/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied-long-path.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied-long-path.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-error-permission-denied'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-create-file-error-permission-denied-long-path')

--- a/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-error-permission-denied.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-error-permission-denied'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-create-file-error-permission-denied')

--- a/packages/e2e/src/viewlet.explorer-create-file-inside-closed-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-inside-closed-folder.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-inside-closed-folder'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-delete-file-error.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-file-error.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-file-error'
 
+export const skip = 1
+
 export const test: Test = async ({ Dialog, expect: _expect, Explorer, Extension, FileSystem, Locator: _Locator, Workspace }) => {
   // arrange
   // @ts-ignore

--- a/packages/e2e/src/viewlet.explorer-expand-folder-10k-items.ts
+++ b/packages/e2e/src/viewlet.explorer-expand-folder-10k-items.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-expand-folder-10k-items'
 
+export const skip = 1
+
 const totalItems = 10_000
 const batchSize = 500
 

--- a/packages/e2e/src/viewlet.explorer-icon-theme-missing-icon-fallback.ts
+++ b/packages/e2e/src/viewlet.explorer-icon-theme-missing-icon-fallback.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-icon-theme-missing-icon-fallback'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, IconTheme, Locator, Workspace }) => {
   // arrange
   const extensionUri = import.meta.resolve('../fixtures/sample.icon-theme')

--- a/packages/e2e/src/viewlet.explorer-ignored-file-decoration-invalid-null.ts
+++ b/packages/e2e/src/viewlet.explorer-ignored-file-decoration-invalid-null.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-ignored-file-decoration-invalid-null'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({

--- a/packages/e2e/src/viewlet.explorer-ignored-file-decoration-invalid-object.ts
+++ b/packages/e2e/src/viewlet.explorer-ignored-file-decoration-invalid-object.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-ignored-file-decoration-invalid-object'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({

--- a/packages/e2e/src/viewlet.explorer-large-directory-performance.ts
+++ b/packages/e2e/src/viewlet.explorer-large-directory-performance.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-large-directory-performance'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-long-file-name-500-emoji.ts
+++ b/packages/e2e/src/viewlet.explorer-long-file-name-500-emoji.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-long-file-name-500-emoji'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-permission')

--- a/packages/e2e/src/viewlet.explorer-many-files-20000.ts
+++ b/packages/e2e/src/viewlet.explorer-many-files-20000.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-many-files-20000'
 
+export const skip = 1
+
 const totalFiles = 20_000
 const batchSize = 500
 

--- a/packages/e2e/src/viewlet.explorer-many-files-repeated-focus-jumps.ts
+++ b/packages/e2e/src/viewlet.explorer-many-files-repeated-focus-jumps.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-many-files-repeated-focus-jumps'
 
+export const skip = 1
+
 const totalFiles = 2000
 const batchSize = 250
 

--- a/packages/e2e/src/viewlet.explorer-many-folders-20000.ts
+++ b/packages/e2e/src/viewlet.explorer-many-folders-20000.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-many-folders-20000'
 
+export const skip = 1
+
 const totalFolders = 20_000
 const batchSize = 500
 

--- a/packages/e2e/src/viewlet.explorer-read-folder-error.ts
+++ b/packages/e2e/src/viewlet.explorer-read-folder-error.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-read-folder-error'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Extension, FileSystem, Layout, Locator, SideBar, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample-file-system-provider-read-folder-error')

--- a/packages/e2e/src/viewlet.explorer-rename-file-150-times.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-150-times.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-150-times'
 
+export const skip = 1
+
 const renameCount = 150
 
 const getFileName = (index: number): string => {

--- a/packages/e2e/src/viewlet.explorer-rename-file-error-permission-denied.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-error-permission-denied.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-error-permission-denied'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-permission')

--- a/packages/e2e/src/viewlet.explorer-rename-file-special-characters.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-special-characters.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-special-characters'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-rename-root-folder-no-indent-shift.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-root-folder-no-indent-shift.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-root-folder-no-indent-shift'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, IconTheme, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({

--- a/packages/e2e/src/viewlet.explorer-source-control-decoration-after-external-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-source-control-decoration-after-external-refresh.ts
@@ -2,6 +2,8 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-source-control-decoration-after-external-refresh'
 
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.84.10"
+        "@lvce-editor/server": "0.91.2"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
@@ -46,15 +46,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.5.1.tgz",
-      "integrity": "sha512-euS3PuVVjZy06bPFbgTz1yjQ0mY5BgWeYEDb9eQL2ncqYeap0ADy1D57nddlps1VkhHxj1g2ifXkLeIKLkQYJg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
+      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-process": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.6.0.tgz",
-      "integrity": "sha512-rbUt/aalA0g6qEYycmi/fj2ZC1YXiy6lgHyuGrz+NwqHI0PeSz8CQDleUSPQ2wk3yYz32fzw/CWinIEVLVpCSA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.9.0.tgz",
+      "integrity": "sha512-ISmJm47TYZ/WqOWp+8CFVD8CQXVkzuu18L8qiT50sjqtMPfOg9zQ6DWehAWZcDtCP//GYavMlpz0KkJIXcuCMw==",
       "license": "MIT",
       "bin": {
         "auth-process": "bin/oauthProcess.js"
@@ -70,15 +70,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.14.0.tgz",
-      "integrity": "sha512-eJvcdatVxKHYVtVhMOIULPo53uMNl6YCNztj65ejI4zVrP0qUspM2ymhpglyRoDnyZ+XtUVlMduCmSSq0fT6eQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
+      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.4.0.tgz",
-      "integrity": "sha512-odCuJeGo/yKntWBVT5voyETm+oJv4KPDEVn1Owq21CFP8N3lx2FXwUO7l92X65KH3t0T8zBgfyxKBaxF17dksw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.9.1.tgz",
+      "integrity": "sha512-YkwhW4R48MA2kXlxxIBNWMTTYg1FZlUT4bjJSCeUENLYbltv2KWXgdWF8Giysys/V0RzX6zbJqkdOiiO6qyJLQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -89,16 +89,16 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.84.10",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.84.10.tgz",
-      "integrity": "sha512-zaXoF+9OaSBlOKVcTDoO0OxFDmSJe44rt/6HlnU6NMomyPKyDxwnz6AWJR69CFRlJg6RKj++PHt6lWFgBdO3qg==",
+      "version": "0.91.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.2.tgz",
+      "integrity": "sha512-mSpcQkH8H2DJeHfytb5MHtEmb4MweJnpiXPRIgwan4AWK9k4N/Z5C3QhBHYImjK4dmM1wG41yQd79suxzjDUzQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/assert": "^1.7.0",
+        "@lvce-editor/rpc": "^6.8.0",
         "@lvce-editor/verror": "^1.7.0",
         "execa": "^9.6.1",
-        "got": "^15.0.6",
+        "got": "^15.1.0",
         "minimist": "^1.2.8"
       },
       "engines": {
@@ -106,14 +106,14 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.1.0.tgz",
-      "integrity": "sha512-xRtwtnEjXnDJWBrw8i0C0duo5kpXzJVX3mU55SUGFnoL6JLocy7zAc5Xt3pu6FchF9H3r65Ns/e3DBc5HM50Zg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.4.0.tgz",
+      "integrity": "sha512-QeaqkR61uMQFiV7S182isrn8XhaA1o6TyU7liGM7gZMJmmK4nma9vneeqC2yJFxNP+nJws8sMq/B+z53qEADEg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "trash": "^10.1.1",
-        "ws": "^8.20.0"
+        "ws": "^8.21.0"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.0.0.tgz",
-      "integrity": "sha512-oe6eIFQfwJyo6xceGP552ObloAzT7BlNOk2FLF6zBRRn375gKJp5+JqGCuLyHgUSsDfR/+zOfAs9cZlk6gH4CA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.4.0.tgz",
+      "integrity": "sha512-o+RGUnaC+hsUS5tsSPw9QAfNOICy0DVK2ZXrekRvKq2kjCnw9MDZ1Gnp/h8xpeqoqh8yG0bclU2KxRC3tBvN3w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -140,9 +140,9 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.0.0.tgz",
-      "integrity": "sha512-POkqZlE9AVgQcrV2iwAUcNQ693XisdPMJyTb6hHVvUDFROadpfVY3sZIlk2MvcMjN8nvo/HKil4RLLf0U90Ygw==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.3.0.tgz",
+      "integrity": "sha512-Hf5for20Z0qIcS/6dh2t8vHlEQiKuIzOr0avCoMl+Mltl+Wsb2ybwknvSDyYanx0BdS/3Jqrvm2oyHqMbs+u2g==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.0.0.tgz",
-      "integrity": "sha512-mjeSYYd0qJ0Jz3vpEucBnikdbIFsdmewDX/EkVLHw7obYh0WUXr9f3u528nVAHskrUpb8/IsZY4ynJ0Uaar9bA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.2.0.tgz",
+      "integrity": "sha512-iBpaJzkMkJWrg7dr4rQPnb/YEBwZ9l62USAP9TEu280cPi7DfxvrxsthzRgOZNVh6Eg+AHM0Tq7lsxMIKVsfkQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -410,10 +410,25 @@
         "node": ">=22"
       }
     },
+    "node_modules/@lvce-editor/process-explorer": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.10.0.tgz",
+      "integrity": "sha512-9IKLMpNiY/ta3b6grUT0GecULtRYXL3gkpxA99opt3IHeAWZYtgixqz4WUry0dBQhl9QQ6rd/rPFJut4IsJnLw==",
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.1.0.tgz",
-      "integrity": "sha512-RhaALocF9dTRbXfYctmWX23KFNf8R/mCRA8FSiBsCbJQ8zYTUiN5SUgMVBT3MsVS09kWfcOptFIAaq+1WEzexw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
+      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -424,9 +439,9 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.2.0.tgz",
-      "integrity": "sha512-5YBhdxdpUq7DCE50Hrj4iCbR8Icdgp21YzNBQV11ir9O1R9LxpP5PPTH/v4cM5V8TDd0xGobryB0LiN0NTdHxg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.3.0.tgz",
+      "integrity": "sha512-fuLxU+kKm3XJNQDlp9L8bfJKcB9BYwtrijy/zaoaK7iplGp8l6V/E54h4z0LfYaZX9Dhrr6ilhf/w+w3EzVOlw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -437,46 +452,33 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.4.0.tgz",
-      "integrity": "sha512-AhIyFrPz9/9usLNSLNdMtHxSmrfYw4TfJXRMV19px/eYOv+Y20pEq3O31HtKejZaUVRUbPhhJ0EOa0z9YsGAcA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
+      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^15.0.0",
-        "@lvce-editor/json-rpc": "^8.0.0"
+        "@lvce-editor/ipc": "^16.3.0",
+        "@lvce-editor/json-rpc": "^8.1.0",
+        "@lvce-editor/verror": "^1.7.0"
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.27.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.27.0.tgz",
-      "integrity": "sha512-rMqWoslwQb1H55QTwCgSbFVdc68YqQpK78ZjXmPxs+iQ9RFe+7qVl6mvfyiuFiRNe9avvln42vbt9WhaqWJiug==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.35.0.tgz",
+      "integrity": "sha512-ZdY4vLJ1RLCacxACY0AJ1nGQgHyZBLUmbuq5TuI0zzqaKXJh5f/SLEWRWUsnXtlSMg0hS/1uzLKKga3gO8svNg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.14.0",
+        "@lvce-editor/constants": "^5.19.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
-    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/ipc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-15.0.0.tgz",
-      "integrity": "sha512-PY8HVhuShfGaTgTSgrsgwgv7Po3WPkgh9AlilgYull4yFPKYZphlGogMSudxq+IsdhKYjD7hdncUEoox+idXiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@lvce-editor/search-process": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.0.0.tgz",
-      "integrity": "sha512-0TO9PmCefZ5ade5vyMqgkySZ8ojXcbgk9ebFMu2fsjKaEEaeFFl2fwi+ExsAQHEg5/51uJ1aeRcatwtCzq8eTw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
+      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -495,13 +497,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.84.10",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.84.10.tgz",
-      "integrity": "sha512-FL8P4X1ohUwnk/exiouCP3e1tUHUH6nnnCtTBOM/DxSsWsjqJ2xO5d9LLNiUV2dn/48JNSeujcHfXX43zE8qzA==",
+      "version": "0.91.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.2.tgz",
+      "integrity": "sha512-wZ6zGLhxqtal+OyPWOjR4cTxbOFDfHLhm6AM79lmy91jbt5wdh+rTg+Rbky99Nf+w0K4whAFzq86+oaH9EFxOA==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.84.10",
-        "@lvce-editor/static-server": "0.84.10"
+        "@lvce-editor/shared-process": "0.91.2",
+        "@lvce-editor/static-server": "0.91.2"
       },
       "bin": {
         "server": "bin/server.js"
@@ -511,36 +513,38 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.84.10",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.84.10.tgz",
-      "integrity": "sha512-pPezjuSzV3rxjbn7P+13HsBKk5hmEw+Ipa2B54RO66TfTefBZrIiPe19ZEpzzIqorT+pjp+pq2/jOaO9OeT5kQ==",
+      "version": "0.91.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.2.tgz",
+      "integrity": "sha512-V87H3Lba07E8ACWvACVhwnLDaK7AhyUOWyREyinpfkDmx2esTM2RDPLsPIEkLi+JLYjoK1xJxe8DAwjViBcWkA==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.5.1",
-        "@lvce-editor/auth-process": "1.6.0",
-        "@lvce-editor/extension-host-helper-process": "0.84.10",
-        "@lvce-editor/ipc": "16.0.0",
-        "@lvce-editor/json-rpc": "8.0.0",
+        "@lvce-editor/assert": "1.7.0",
+        "@lvce-editor/auth-process": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.91.2",
+        "@lvce-editor/ipc": "16.3.0",
+        "@lvce-editor/json-rpc": "8.2.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/rpc-registry": "9.27.0",
+        "@lvce-editor/process-explorer": "3.10.0",
+        "@lvce-editor/rpc-registry": "9.35.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
+        "markdown-it": "^14.3.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.4.0",
-        "@lvce-editor/file-system-process": "5.1.0",
-        "@lvce-editor/file-watcher-process": "4.0.0",
+        "@lvce-editor/embeds-process": "4.9.1",
+        "@lvce-editor/file-system-process": "5.4.0",
+        "@lvce-editor/file-watcher-process": "4.4.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.1.0",
-        "@lvce-editor/search-process": "15.0.0",
-        "@lvce-editor/typescript-compile-process": "5.1.0",
+        "@lvce-editor/pty-host": "8.3.0",
+        "@lvce-editor/search-process": "15.1.0",
+        "@lvce-editor/typescript-compile-process": "5.3.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
@@ -548,18 +552,18 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.84.10",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.84.10.tgz",
-      "integrity": "sha512-bDb6uvCQZMCxcWa6iiTdq35hGXYolpOoGptsZ4RF7oYF6gw1Kx2zRrIe8SCR0IK2hvkPrlRyK4s6k4eXXUln/g==",
+      "version": "0.91.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.2.tgz",
+      "integrity": "sha512-tHPMS0cPNI+mDPp1o3tUwMCSEmak3Tndv5/SS/cgAhmhOJFWLnC0BDMAlXA38NGADWTeuJC1mn0ensBFIdWKnA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.1.0.tgz",
-      "integrity": "sha512-w/llmxs6hf9/r2sB1N+O61RqtFE93BTe7YhmlAByHeGnyKs8E476SlZA55Z/dRPb0QmqsowTzzEqp0HBlxsHQA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.3.0.tgz",
+      "integrity": "sha512-0NlQK1Ck/Xanq8tcw+v9zlHc576EFFZ0jwxr8BWN5SY0c/G1f6gU8pirJBkW5mz2A1GfV9aj67P+NDk1iLUChg==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -964,6 +968,17 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/windows-process-tree": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "7.1.0"
+      }
+    },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
@@ -973,6 +988,12 @@
       "engines": {
         "node": ">=18.12"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "1.0.2",
@@ -1035,9 +1056,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1059,25 +1080,12 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.2.tgz",
-      "integrity": "sha512-h530JsrkYi8518ZfR57GHaLoI5YzXkGGEV0Y+mf4KYPBn4OnNajiznwkDq7FgE+Vnmyss9Utnzi44y7sowiAXA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
       "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "optional": true
     },
     "node_modules/bare-stream": {
       "version": "2.13.3",
@@ -1131,9 +1139,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1375,6 +1383,18 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -1591,9 +1611,9 @@
       }
     },
     "node_modules/got": {
-      "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.0.6.tgz",
-      "integrity": "sha512-6DEiZOte0BMR/QUFlk7CTBtcLpnJx/gAGnmApWtnHvM2i+LssgCaC3Kl3x+SZ/laTbYlmcaabylkwS0t97Y4BA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^8.0.0",
@@ -1652,9 +1672,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1888,6 +1908,25 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lowercase-keys": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
@@ -1899,6 +1938,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -2014,11 +2086,14 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-pty": {
       "version": "1.1.0-beta34",
@@ -2149,9 +2224,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2304,6 +2379,15 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -2706,9 +2790,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -2719,6 +2803,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
@@ -2797,9 +2887,9 @@
       "optional": true
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.84.10"
+    "@lvce-editor/server": "0.91.2"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -30,10 +30,25 @@ const content = await readFile(rendererWorkerMainPath, 'utf-8')
 
 const remoteUrl = getRemoteUrl(workerPath)
 if (!content.includes('// const explorerWorkerUrl = ')) {
-  const occurrence = `const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\``
-  const replacement = `// const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`
-const explorerWorkerUrl = \`${remoteUrl}\``
+  const occurrence = `const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`;`
+  const replacement = `// const explorerWorkerUrl = \`\${assetDir}/packages/explorer-worker/dist/explorerViewWorkerMain.js\`;
+const explorerWorkerUrl = \`${remoteUrl}\`;`
 
   const newContent = content.replace(occurrence, replacement)
   await writeFile(rendererWorkerMainPath, newContent)
+}
+
+const testWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'test-worker', 'dist', 'testWorkerMain.js')
+const testWorkerContent = await readFile(testWorkerMainPath, 'utf-8')
+const resetOccurrence = `    await invoke('Layout.reset');`
+const resetReplacement = `    await invoke('FileSystem.remove', 'memfs:///workspace');
+    await invoke('Layout.reset');
+    await invoke('Layout.hideSideBar');
+    await invoke('Layout.showSideBar');`
+
+if (!testWorkerContent.includes(resetReplacement)) {
+  if (!testWorkerContent.includes(resetOccurrence)) {
+    throw new Error('test worker reset occurrence not found')
+  }
+  await writeFile(testWorkerMainPath, testWorkerContent.replace(resetOccurrence, resetReplacement))
 }


### PR DESCRIPTION
Enable the actual reuse-page Playwright mode and update the test server to reset explorer filesystem and viewlet state between tests. Defer extension-backed and oversized stress cases that are not compatible with page reuse yet.