### PR TITLE
feature: let ci matrix jobs finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Configure the push CI matrix to avoid cancelling macOS or Windows when another operating-system job fails, matching the existing PR workflow behavior.