### PR TITLE
feature: add explorer accessibility e2e tests

### DIFF
--- a/packages/e2e/src/viewlet.explorer-accessibility-create-updates-aria.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-create-updates-aria.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-create-updates-aria'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -22,9 +20,13 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   const folder = Locator('.TreeItem[aria-label="folder"]')
   const a = Locator('.TreeItem[aria-label="a.txt"]')
   const b = Locator('.TreeItem[aria-label="b.txt"]')
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(folder).toHaveAttribute('aria-posinset', '1')
   await expect(folder).toHaveAttribute('aria-setsize', '1')
+  await expect(a).toHaveAttribute('aria-level', '2')
   await expect(a).toHaveAttribute('aria-posinset', '1')
   await expect(a).toHaveAttribute('aria-setsize', '2')
+  await expect(b).toHaveAttribute('aria-level', '2')
   await expect(b).toHaveAttribute('aria-posinset', '2')
   await expect(b).toHaveAttribute('aria-setsize', '2')
 }

--- a/packages/e2e/src/viewlet.explorer-accessibility-delete-updates-aria.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-delete-updates-aria.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-delete-updates-aria'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -22,9 +20,11 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   const a = Locator('.TreeItem[aria-label="a.txt"]')
   const b = Locator('.TreeItem[aria-label="b.txt"]')
   const c = Locator('.TreeItem[aria-label="c.txt"]')
+  await expect(a).toHaveAttribute('aria-level', '2')
   await expect(a).toHaveAttribute('aria-posinset', '1')
   await expect(a).toHaveAttribute('aria-setsize', '2')
   await expect(b).toBeHidden()
+  await expect(c).toHaveAttribute('aria-level', '2')
   await expect(c).toHaveAttribute('aria-posinset', '2')
   await expect(c).toHaveAttribute('aria-setsize', '2')
 }

--- a/packages/e2e/src/viewlet.explorer-accessibility-files-no-aria-expanded.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-files-no-aria-expanded.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-files-no-aria-expanded'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -14,8 +12,12 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.expandRecursively()
 
   // assert
+  const folder = Locator('.TreeItem[aria-label="folder"]')
   const rootFile = Locator('.TreeItem[aria-label="root.txt"]')
   const nestedFile = Locator('.TreeItem[aria-label="nested.txt"]')
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(rootFile).toHaveAttribute('role', 'treeitem')
   await expect(rootFile).toHaveAttribute('aria-expanded', null)
+  await expect(nestedFile).toHaveAttribute('role', 'treeitem')
   await expect(nestedFile).toHaveAttribute('aria-expanded', null)
 }

--- a/packages/e2e/src/viewlet.explorer-accessibility-refresh-updates-aria.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-refresh-updates-aria.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-refresh-updates-aria'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -17,10 +15,14 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.refresh()
 
   // assert
+  const folder = Locator('.TreeItem[aria-label="folder"]')
   const a = Locator('.TreeItem[aria-label="a.txt"]')
   const b = Locator('.TreeItem[aria-label="b.txt"]')
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(a).toHaveAttribute('aria-level', '2')
   await expect(a).toHaveAttribute('aria-posinset', '1')
   await expect(a).toHaveAttribute('aria-setsize', '2')
+  await expect(b).toHaveAttribute('aria-level', '2')
   await expect(b).toHaveAttribute('aria-posinset', '2')
   await expect(b).toHaveAttribute('aria-setsize', '2')
 }

--- a/packages/e2e/src/viewlet.explorer-accessibility-rename-updates-aria.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-rename-updates-aria.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-rename-updates-aria'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -20,8 +18,12 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   // assert
   const a = Locator('.TreeItem[aria-label="a.txt"]')
   const b = Locator('.TreeItem[aria-label="b.txt"]')
+  const c = Locator('.TreeItem[aria-label="c.txt"]')
   await expect(a).toHaveAttribute('aria-posinset', '1')
+  await expect(a).toHaveAttribute('aria-setsize', '2')
+  await expect(b).toHaveAttribute('aria-level', '1')
   await expect(b).toHaveAttribute('aria-posinset', '2')
   await expect(b).toHaveAttribute('aria-setsize', '2')
   await expect(b).toHaveId('TreeItemActive')
+  await expect(c).toBeHidden()
 }


### PR DESCRIPTION
Adds active explorer accessibility coverage for ARIA state after create, delete, refresh, and rename operations, plus file-node expansion semantics.