### PR TITLE
feature: open explorer files in preview tabs

### DIFF
--- a/packages/build/src/build-static.ts
+++ b/packages/build/src/build-static.ts
@@ -36,4 +36,7 @@ if (!content.includes(occurrence)) {
 const newContent = content.replace(occurrence, replacement)
 await writeFile(rendererWorkerPath, newContent)
 
+const explorerWorkerPath = join(root, 'dist', commitHash, 'packages', 'explorer-worker', 'dist', 'explorerViewWorkerMain.js')
+await cp(workerPath, explorerWorkerPath)
+
 await cp(join(root, 'dist'), join(root, '.tmp', 'static'), { recursive: true })

--- a/packages/e2e/src/viewlet.explorer-click-file-opens-in-editor.ts
+++ b/packages/e2e/src/viewlet.explorer-click-file-opens-in-editor.ts
@@ -13,6 +13,8 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.handleClick(1)
 
   // assert - the file should be opened in the editor
-  const editorTab = Locator('[title*="file2.txt"]').first()
+  const editorTab = Locator('.MainTab[title$="file2.txt"]')
   await expect(editorTab).toBeVisible()
+  await expect(editorTab).toHaveClass('MainTabPreview')
+  await expect(editorTab).toHaveCSS('font-style', 'italic')
 }

--- a/packages/e2e/src/viewlet.explorer-click-pinned-tab-keeps-it-pinned.ts
+++ b/packages/e2e/src/viewlet.explorer-click-pinned-tab-keeps-it-pinned.ts
@@ -11,9 +11,8 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Main, 
   await Main.openUri(pinnedFile)
   await Explorer.handleClick(0)
 
-  const tab = Locator('.MainTab[title$="pinned.txt"]')
+  const tab = Locator('.MainTab:not(.MainTabPreview)[title$="pinned.txt"]')
   const tabs = Locator('.MainTab')
   await expect(tab).toBeVisible()
-  await expect(tab).not.toHaveClass('MainTabPreview')
   await expect(tabs).toHaveCount(1)
 }

--- a/packages/e2e/src/viewlet.explorer-click-pinned-tab-keeps-it-pinned.ts
+++ b/packages/e2e/src/viewlet.explorer-click-pinned-tab-keeps-it-pinned.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-click-pinned-tab-keeps-it-pinned'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const pinnedFile = `${tmpDir}/pinned.txt`
+  await FileSystem.writeFile(pinnedFile, 'pinned')
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(pinnedFile)
+  await Explorer.handleClick(0)
+
+  const tab = Locator('.MainTab[title$="pinned.txt"]')
+  const tabs = Locator('.MainTab')
+  await expect(tab).toBeVisible()
+  await expect(tab).not.toHaveClass('MainTabPreview')
+  await expect(tabs).toHaveCount(1)
+}

--- a/packages/e2e/src/viewlet.explorer-create-file-opens-in-editor.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-opens-in-editor.ts
@@ -30,7 +30,6 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // assert - file should be opened in editor (check for editor tab or editor view)
   // The file should be opened, which means there should be an editor tab or editor content visible
-  const editorTab = Locator('.MainTab[title$="new-file.txt"]')
+  const editorTab = Locator('.MainTab:not(.MainTabPreview)[title$="new-file.txt"]')
   await expect(editorTab).toBeVisible()
-  await expect(editorTab).not.toHaveClass('MainTabPreview')
 }

--- a/packages/e2e/src/viewlet.explorer-create-file-opens-in-editor.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-opens-in-editor.ts
@@ -30,6 +30,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // assert - file should be opened in editor (check for editor tab or editor view)
   // The file should be opened, which means there should be an editor tab or editor content visible
-  const editorTab = Locator('[title*="new-file.txt"]').first()
+  const editorTab = Locator('.MainTab[title$="new-file.txt"]')
   await expect(editorTab).toBeVisible()
+  await expect(editorTab).not.toHaveClass('MainTabPreview')
 }

--- a/packages/e2e/src/viewlet.explorer-preview-keeps-pinned-tab.ts
+++ b/packages/e2e/src/viewlet.explorer-preview-keeps-pinned-tab.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-preview-keeps-pinned-tab'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const pinnedFile = `${tmpDir}/a-pinned.txt`
+  await FileSystem.setFiles([
+    { content: 'pinned', uri: pinnedFile },
+    { content: 'preview', uri: `${tmpDir}/b-preview.txt` },
+  ])
+  await Workspace.setPath(tmpDir)
+
+  await Main.openUri(pinnedFile)
+  await Explorer.handleClick(1)
+
+  const pinnedTab = Locator('.MainTab[title$="a-pinned.txt"]')
+  const previewTab = Locator('.MainTabPreview[title$="b-preview.txt"]')
+  const tabs = Locator('.MainTab')
+  await expect(pinnedTab).toBeVisible()
+  await expect(previewTab).toBeVisible()
+  await expect(tabs).toHaveCount(2)
+}

--- a/packages/e2e/src/viewlet.explorer-preview-tab-replaced-repeatedly.ts
+++ b/packages/e2e/src/viewlet.explorer-preview-tab-replaced-repeatedly.ts
@@ -1,0 +1,23 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-preview-tab-replaced-repeatedly'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.setFiles([
+    { content: 'first', uri: `${tmpDir}/a-first.txt` },
+    { content: 'second', uri: `${tmpDir}/b-second.txt` },
+  ])
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.handleClick(0)
+  await Explorer.handleClick(1)
+  await Explorer.handleClick(0)
+
+  const firstTab = Locator('.MainTabPreview[title$="a-first.txt"]')
+  const secondTab = Locator('.MainTab[title$="b-second.txt"]')
+  const tabs = Locator('.MainTab')
+  await expect(firstTab).toBeVisible()
+  await expect(secondTab).toBeHidden()
+  await expect(tabs).toHaveCount(1)
+}

--- a/packages/e2e/src/viewlet.explorer-preview-tab-replaced.ts
+++ b/packages/e2e/src/viewlet.explorer-preview-tab-replaced.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-preview-tab-replaced'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.setFiles([
+    { content: 'first', uri: `${tmpDir}/a-first.txt` },
+    { content: 'second', uri: `${tmpDir}/b-second.txt` },
+  ])
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.handleClick(0)
+  await Explorer.handleClick(1)
+
+  const firstTab = Locator('.MainTab[title$="a-first.txt"]')
+  const secondTab = Locator('.MainTabPreview[title$="b-second.txt"]')
+  const tabs = Locator('.MainTab')
+  await expect(firstTab).toBeHidden()
+  await expect(secondTab).toBeVisible()
+  await expect(tabs).toHaveCount(1)
+}

--- a/packages/explorer-view/src/parts/HandleClickFile/HandleClickFile.ts
+++ b/packages/explorer-view/src/parts/HandleClickFile/HandleClickFile.ts
@@ -3,7 +3,9 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as OpenUri from '../OpenUri/OpenUri.ts'
 
 export const handleClickFile = async (state: ExplorerState, dirent: ExplorerItem, index: number, keepFocus = false): Promise<ExplorerState> => {
-  await OpenUri.openUri(dirent.path, !keepFocus)
+  await OpenUri.openUri(dirent.path, !keepFocus, {
+    preview: true,
+  })
   return {
     ...state,
     focused: keepFocus,

--- a/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
+++ b/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
@@ -1,5 +1,13 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
-export const openUri = async (uri: string, focus: boolean): Promise<void> => {
+interface OpenUriOptions {
+  readonly preview?: boolean
+}
+
+export const openUri = async (uri: string, focus: boolean, options?: OpenUriOptions): Promise<void> => {
+  if (options) {
+    await RendererWorker.openUri(uri, /* focus */ focus, options)
+    return
+  }
   await RendererWorker.openUri(uri, /* focus */ focus)
 }

--- a/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
+++ b/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
@@ -6,7 +6,14 @@ interface OpenUriOptions {
 
 export const openUri = async (uri: string, focus: boolean, options?: OpenUriOptions): Promise<void> => {
   if (options) {
-    await RendererWorker.openUri(uri, /* focus */ focus, options)
+    await RendererWorker.invoke('Main.openInput', {
+      editorInput: {
+        type: 'editor',
+        uri,
+      },
+      focu: focus,
+      preview: options.preview ?? false,
+    })
     return
   }
   await RendererWorker.openUri(uri, /* focus */ focus)

--- a/packages/explorer-view/test/HandleClickSymlink.test.ts
+++ b/packages/explorer-view/test/HandleClickSymlink.test.ts
@@ -25,7 +25,7 @@ test('handleClickSymLink - file symlink', async () => {
     'FileSystem.stat'() {
       return DirentType.File
     },
-    'Main.openUri'() {
+    'Main.openInput'() {
       return undefined
     },
   })
@@ -34,7 +34,17 @@ test('handleClickSymLink - file symlink', async () => {
   expect(mockRpc.invocations).toEqual([
     ['FileSystem.getRealPath', '/test/symlink'],
     ['FileSystem.stat', '/test/real-file'],
-    ['Main.openUri', '/test/symlink', true, { preview: true }],
+    [
+      'Main.openInput',
+      {
+        editorInput: {
+          type: 'editor',
+          uri: '/test/symlink',
+        },
+        focu: true,
+        preview: true,
+      },
+    ],
   ])
 })
 

--- a/packages/explorer-view/test/HandleClickSymlink.test.ts
+++ b/packages/explorer-view/test/HandleClickSymlink.test.ts
@@ -34,7 +34,7 @@ test('handleClickSymLink - file symlink', async () => {
   expect(mockRpc.invocations).toEqual([
     ['FileSystem.getRealPath', '/test/symlink'],
     ['FileSystem.stat', '/test/real-file'],
-    ['Main.openUri', '/test/symlink', true],
+    ['Main.openUri', '/test/symlink', true, { preview: true }],
   ])
 })
 

--- a/packages/explorer-view/test/OpenUri.test.ts
+++ b/packages/explorer-view/test/OpenUri.test.ts
@@ -22,13 +22,25 @@ test('openUri calls ParentRpc.invoke with focus false', async () => {
   expect(mockRpc.invocations).toEqual([['Main.openUri', mockUri, mockFocus]])
 })
 
-test('openUri passes preview options to the main area', async () => {
+test('openUri opens preview files through the main area input API', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'Main.openUri'() {},
+    'Main.openInput'() {},
   })
   const mockUri = 'file:///test.txt'
   await openUri(mockUri, true, {
     preview: true,
   })
-  expect(mockRpc.invocations).toEqual([['Main.openUri', mockUri, true, { preview: true }]])
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Main.openInput',
+      {
+        editorInput: {
+          type: 'editor',
+          uri: mockUri,
+        },
+        focu: true,
+        preview: true,
+      },
+    ],
+  ])
 })

--- a/packages/explorer-view/test/OpenUri.test.ts
+++ b/packages/explorer-view/test/OpenUri.test.ts
@@ -21,3 +21,14 @@ test('openUri calls ParentRpc.invoke with focus false', async () => {
   await openUri(mockUri, mockFocus)
   expect(mockRpc.invocations).toEqual([['Main.openUri', mockUri, mockFocus]])
 })
+
+test('openUri passes preview options to the main area', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri'() {},
+  })
+  const mockUri = 'file:///test.txt'
+  await openUri(mockUri, true, {
+    preview: true,
+  })
+  expect(mockRpc.invocations).toEqual([['Main.openUri', mockUri, true, { preview: true }]])
+})


### PR DESCRIPTION
Opens Explorer file clicks as preview tabs while keeping newly created files pinned. Adds Explorer integration coverage for preview styling, replacement, repeated replacement, and coexistence with pinned tabs.