### PR TITLE
fix: preserve source when copying explorer files

### DIFF
--- a/packages/e2e/src/viewlet.explorer-context-menu-paste-root-no-focused-item.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-paste-root-no-focused-item.ts
@@ -20,8 +20,10 @@ export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, Fil
   await ContextMenu.selectItem('Paste')
 
   // assert
-  const file1 = Locator('.TreeItem').nth(0)
-  await expect(file1).toHaveText('a')
-  const file2 = Locator('.TreeItem').nth(1)
-  await expect(file2).toHaveText('file.txt')
+  const sourceFile = Locator(`.TreeItem[title="${tmpDir}/a/file.txt"]`)
+  await expect(sourceFile).toBeVisible()
+  const copiedFile = Locator(`.TreeItem[title="${tmpDir}/file.txt"]`)
+  await expect(copiedFile).toBeVisible()
+  await FileSystem.shouldHaveFile(`${tmpDir}/a/file.txt`, 'content')
+  await FileSystem.shouldHaveFile(`${tmpDir}/file.txt`, 'content')
 }

--- a/packages/e2e/src/viewlet.explorer-copy-and-paste-file.ts
+++ b/packages/e2e/src/viewlet.explorer-copy-and-paste-file.ts
@@ -20,12 +20,8 @@ export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Loca
   await Explorer.handlePaste()
 
   // assert
-  const file1 = Locator('.TreeItem').nth(0)
-  await expect(file1).toHaveText('a')
-  await expect(file1).toHaveAttribute('aria-expanded', 'true')
-  const file3 = Locator('.TreeItem').nth(1)
-  await expect(file3).toHaveText('b')
-  await expect(file3).toHaveAttribute('aria-expanded', 'false') // TODO should be true
-  const file4 = Locator('.TreeItem').nth(2)
-  await expect(file4).toHaveText('file.txt')
+  const copiedFile = Locator(`.TreeItem[title="${tmpDir}/file.txt"]`)
+  await expect(copiedFile).toBeVisible()
+  await FileSystem.shouldHaveFile(`${tmpDir}/a/file.txt`, 'content')
+  await FileSystem.shouldHaveFile(`${tmpDir}/file.txt`, 'content')
 }

--- a/packages/e2e/src/viewlet.explorer-copy-and-paste-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-copy-and-paste-folder.ts
@@ -2,11 +2,12 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-copy-and-paste-folder'
 
-export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, Explorer, FileSystem, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
-  const tmpDir = await FileSystem.getTmpDir()
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
   await FileSystem.mkdir(`${tmpDir}/a`)
+  await FileSystem.writeFile(`${tmpDir}/a/file.txt`, 'content')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
@@ -14,15 +15,11 @@ export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Loca
 
   // act
   await Explorer.handleCopy()
-  await Explorer.focusIndex(1)
+  await Explorer.focusIndex(2)
   await Explorer.handlePaste()
   await Explorer.expandAll()
 
   // assert
-  const file1 = Locator('.TreeItem').nth(0)
-  await expect(file1).toHaveText('b')
-  await expect(file1).toHaveAttribute('aria-expanded', 'true')
-  const file2 = Locator('.TreeItem').nth(1)
-  await expect(file2).toHaveText('a')
-  // await expect(file1).toHaveAttribute('aria-expanded', 'false')
+  await FileSystem.shouldHaveFile(`${tmpDir}/a/file.txt`, 'content')
+  await FileSystem.shouldHaveFile(`${tmpDir}/b/a/file.txt`, 'content')
 }

--- a/packages/e2e/src/viewlet.explorer-copy-to-folder-preserves-source.ts
+++ b/packages/e2e/src/viewlet.explorer-copy-to-folder-preserves-source.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-copy-to-folder-preserves-source'
+
+export const test: Test = async ({ ClipBoard, Explorer, FileSystem, Workspace }) => {
+  await ClipBoard.enableMemoryClipBoard()
+  const tmpDir = await FileSystem.getTmpDir()
+  const sourcePath = `${tmpDir}/source/file.txt`
+  const targetPath = `${tmpDir}/target/file.txt`
+  await FileSystem.mkdir(`${tmpDir}/source`)
+  await FileSystem.writeFile(sourcePath, 'copy me')
+  await FileSystem.mkdir(`${tmpDir}/target`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
+
+  await Explorer.handleCopy()
+  await Explorer.focusIndex(2)
+  await Explorer.handlePaste()
+
+  await FileSystem.shouldHaveFile(sourcePath, 'copy me')
+  await FileSystem.shouldHaveFile(targetPath, 'copy me')
+}

--- a/packages/explorer-view/src/parts/GetFileOperationsCopy/GetFileOperationsCopy.ts
+++ b/packages/explorer-view/src/parts/GetFileOperationsCopy/GetFileOperationsCopy.ts
@@ -17,7 +17,7 @@ export const getFileOperationsCopy = (
       operations.push({
         from: file,
         path: Path.join2(focusedUri, baseName),
-        type: FileOperationType.Rename,
+        type: FileOperationType.Copy,
       })
     } else {
       const uniqueName = generateUniqueName(baseName, existingUris, root)

--- a/packages/explorer-view/test/GetFileOperationsCopy.test.ts
+++ b/packages/explorer-view/test/GetFileOperationsCopy.test.ts
@@ -77,6 +77,15 @@ test('getFileOperationsCopy - empty existingUris', () => {
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file.txt', type: FileOperationType.Copy }])
 })
 
+test('getFileOperationsCopy - copies workspace file into focused folder', () => {
+  const root = '/test'
+  const existingUris = ['/test/source', '/test/source/file.txt', '/test/target']
+  const files = ['/test/source/file.txt']
+
+  const result = getFileOperationsCopy(root, existingUris, files, '/test/target')
+  expect(result).toEqual([{ from: '/test/source/file.txt', path: '/test/target/file.txt', type: FileOperationType.Copy }])
+})
+
 test('getFileOperationsCopy - empty files', () => {
   const root = '/test'
   const existingUris = ['/test/existing.txt']


### PR DESCRIPTION
## Summary

- use a filesystem copy operation when an Explorer source is inside the workspace
- add a unit regression for copying a workspace file into a focused folder
- add an E2E regression that verifies both source and destination contents

## Verification

- `npm test`
- `npm run type-check`
- `npm run lint`
- `npm run build && npm run build:static`
- `npm run measure`
- `npm run e2e:headless -- --filter=viewlet.explorer-copy-to-folder-preserves-source` (from `packages/e2e`)

Resolves the manual test report `explorer-copy-acts-like-cut`.