### PR TITLE
fix: recompute explorer diff before rendering

### DIFF
--- a/packages/explorer-view/src/parts/Render2/Render2.ts
+++ b/packages/explorer-view/src/parts/Render2/Render2.ts
@@ -1,8 +1,10 @@
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
+import * as Diff from '../Diff/Diff.ts'
 import * as ExplorerStates from '../ExplorerStates/ExplorerStates.ts'
 
-export const render2 = (uid: number, diffResult: readonly number[]): readonly any[] => {
+export const render2 = (uid: number, _diffResult: readonly number[]): readonly any[] => {
   const { oldState, scheduledState } = ExplorerStates.get(uid)
+  const diffResult = Diff.diff(oldState, scheduledState)
   ExplorerStates.set(uid, scheduledState, scheduledState)
   const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
   return commands

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -1,51 +1,18 @@
 import { test, expect } from '@jest/globals'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DiffType from '../src/parts/DiffType/DiffType.ts'
-import * as DomEventListenerFunctions from '../src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
 
-test('render2 - basic', () => {
+test('render2 - recomputes a stale diff before rendering', () => {
   const uid = 1
-  const diffResult = [DiffType.RenderItems, DiffType.RenderFocus]
+  const staleDiffResult = [DiffType.RenderFocus]
   const oldState = createDefaultState()
-  const newState = { ...oldState }
+  const newState = {
+    ...oldState,
+    items: [...oldState.items],
+  }
   ExplorerStates.set(uid, oldState, newState)
-  const result = Render2.render2(uid, diffResult)
-  expect(result).toEqual([
-    [
-      'Viewlet.setDom2',
-      1,
-      [
-        {
-          childCount: 1,
-          className: 'Viewlet Explorer',
-          role: 'none',
-          type: 4,
-        },
-        {
-          ariaActiveDescendant: 'TreeItemActive',
-          ariaLabel: 'Files Explorer',
-          childCount: 0,
-          className: 'ListItems',
-          onBlur: DomEventListenerFunctions.HandleListBlur,
-          onClick: DomEventListenerFunctions.HandleClick,
-          onContextMenu: DomEventListenerFunctions.HandleContextMenu,
-          onDblClick: DomEventListenerFunctions.HandleDoubleClick,
-          onDragEnd: DomEventListenerFunctions.HandleDragEnd,
-          onDragLeave: DomEventListenerFunctions.HandleDragLeave,
-          onDragOver: DomEventListenerFunctions.HandleDragOver,
-          onDragStart: DomEventListenerFunctions.HandleDragStart,
-          onDrop: DomEventListenerFunctions.HandleDrop,
-          onFocus: DomEventListenerFunctions.HandleListFocus,
-          onPointerDown: DomEventListenerFunctions.HandlePointerDown,
-          onWheel: DomEventListenerFunctions.HandleWheel,
-          // onKeyDown: 'handleListKeyDown',
-          role: 'tree',
-          tabIndex: 0,
-          type: 4,
-        },
-      ],
-    ],
-  ])
+  const result = Render2.render2(uid, staleDiffResult)
+  expect(result).toEqual([['Viewlet.setPatches', 1, []]])
 })


### PR DESCRIPTION
## Summary
- recompute the Explorer diff from the current worker state inside `render2`
- ignore a caller-supplied diff that may have become stale between the separate `diff2` and `render2` RPC calls
- add a regression test proving a stale supplied diff is replaced before rendering

## Evidence
The repeated diagnostic run caught `render2` receiving non-empty diffs after Explorer state had already advanced to identical old/scheduled states. This reproduced in `rapid-toolbar-clicks`, `create-file-switch-folders`, and locally in `rename-file-twice`.

Diagnostic job: https://github.com/lvce-editor/explorer-view/actions/runs/29508025531/job/87653811776
Diagnostic PR: https://github.com/lvce-editor/explorer-view/pull/1742

## Validation
- focused Render2 regression test
- repository type-check
- targeted eslint and prettier checks