### PR TITLE
fix: confirm explorer deletions by default

### DIFF
--- a/packages/e2e/src/viewlet.explorer-accessibility-delete-updates-aria.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-delete-updates-aria.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-delete-updates-aria'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/a.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-collapse-parent-clears-hidden-child-selection.ts
+++ b/packages/e2e/src/viewlet.explorer-collapse-parent-clears-hidden-child-selection.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-collapse-parent-clears-hidden-child-selection'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-context-menu-delete-file-with-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-delete-file-with-focus.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-delete-file-with-focus'
 
-export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ContextMenu, Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-context-menu-delete-file.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-delete-file.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-delete-file'
 
-export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ContextMenu, Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-context-menu-delete-unselected-with-selection.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-delete-unselected-with-selection.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-delete-unselected-with-selection'
 
-export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ContextMenu, Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-delete-collapsed-folder-with-selected-hidden-child.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-collapsed-folder-with-selected-hidden-child.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-collapsed-folder-with-selected-hidden-child'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, 'child')

--- a/packages/e2e/src/viewlet.explorer-delete-expanded-folder-hides-children-and-focuses-next.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-expanded-folder-hides-children-and-focuses-next.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-expanded-folder-hides-children-and-focuses-next'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder-1`)
   await FileSystem.writeFile(`${tmpDir}/folder-1/a.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-delete-file-empty-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-file-empty-workspace.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-file-empty-workspace'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await Workspace.setPath(tmpDir)
 

--- a/packages/e2e/src/viewlet.explorer-delete-file-no-focused-item.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-file-no-focused-item.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-file-no-focused-item'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file-1.txt`, 'a')
   await FileSystem.writeFile(`${tmpDir}/file-2.txt`, 'b')

--- a/packages/e2e/src/viewlet.explorer-delete-file.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-file.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-last-file'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-delete-folder-with-items.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-folder-with-items.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-folder-with-items'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder-1`)
   await FileSystem.writeFile(`${tmpDir}/folder-1/a.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-delete-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-folder.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-folder'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder-1`)
   await FileSystem.mkdir(`${tmpDir}/folder-2`)

--- a/packages/e2e/src/viewlet.explorer-delete-last-file.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-last-file.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-file'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)

--- a/packages/e2e/src/viewlet.explorer-delete-multiple-files-at-once.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-multiple-files-at-once.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-multiple-files'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-delete-multiple-files-focuses-remaining-item.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-multiple-files-focuses-remaining-item.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-multiple-files-focuses-remaining-item'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-delete-multiple-files.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-multiple-files.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-multiple-files'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-delete-nested-middle-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-nested-middle-folder.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-nested-middle-folder'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b/c/d`)
   await FileSystem.writeFile(`${tmpDir}/a/b/c/d/e.txt`, 'deep')

--- a/packages/e2e/src/viewlet.explorer-delete-non-empty-folder-cancel.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-non-empty-folder-cancel.ts
@@ -1,0 +1,28 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-delete-non-empty-folder-cancel'
+
+export const test: Test = async ({ Dialog, Explorer, FileSystem, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  const folderPath = `${tmpDir}/fixture`
+  const filePath = `${folderPath}/important.txt`
+  await FileSystem.mkdir(folderPath)
+  await FileSystem.writeFile(filePath, 'important')
+  let confirmMessage = ''
+  await Dialog.mockConfirm((...args: readonly unknown[]) => {
+    confirmMessage = String(args[0])
+    return false
+  })
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  // act
+  await Explorer.removeDirent()
+
+  // assert
+  if (confirmMessage !== `Are you sure you want to delete "${folderPath}"?`) {
+    throw new Error(`unexpected confirm message: ${confirmMessage}`)
+  }
+  await FileSystem.shouldHaveFile(filePath, 'important')
+}

--- a/packages/e2e/src/viewlet.explorer-delete-open-file-keeps-editor-stable.ts
+++ b/packages/e2e/src/viewlet.explorer-delete-open-file-keeps-editor-stable.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-delete-open-file-keeps-editor-stable'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/open.txt`, 'content')
   await FileSystem.writeFile(`${tmpDir}/other.txt`, 'other')

--- a/packages/e2e/src/viewlet.explorer-focus-after-delete-last.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-after-delete-last.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-after-delete-last'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-focus-after-delete-middle.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-after-delete-middle.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-after-delete-middle'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')

--- a/packages/e2e/src/viewlet.explorer-keyboard-context-menu-multi-selection.ts
+++ b/packages/e2e/src/viewlet.explorer-keyboard-context-menu-multi-selection.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-keyboard-context-menu-multi-selection'
 
-export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ContextMenu, Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-keyboard-navigation.ts
+++ b/packages/e2e/src/viewlet.explorer-keyboard-navigation.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-keyboard-navigation'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b`)
   await FileSystem.writeFile(`${tmpDir}/a/b/c.txt`, 'ccccc')

--- a/packages/e2e/src/viewlet.explorer-select-all-large-directory-delete-no-stale-rows.ts
+++ b/packages/e2e/src/viewlet.explorer-select-all-large-directory-delete-no-stale-rows.ts
@@ -4,8 +4,9 @@ export const name = 'viewlet.explorer-select-all-large-directory-delete-no-stale
 
 export const skip = 1
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   for (let i = 0; i < 500; i++) {
     await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')

--- a/packages/e2e/src/viewlet.explorer-select-all-then-delete-files.ts
+++ b/packages/e2e/src/viewlet.explorer-select-all-then-delete-files.ts
@@ -2,8 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-select-all-then-delete-files'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   for (let index = 0; index < 10; index++) {
     await FileSystem.writeFile(`${tmpDir}/file-${index}.txt`, `content ${index}`)

--- a/packages/e2e/src/viewlet.explorer-undo-delete-file.ts
+++ b/packages/e2e/src/viewlet.explorer-undo-delete-file.ts
@@ -4,8 +4,9 @@ export const name = 'viewlet.explorer-undo-delete-file'
 
 export const skip = 1
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
   await Workspace.setPath(tmpDir)

--- a/packages/e2e/src/viewlet.explorer-undo-delete-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-undo-delete-folder.ts
@@ -4,8 +4,9 @@ export const name = 'viewlet.explorer-undo-delete-folder'
 
 export const skip = 1
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
+  await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/nested.txt`, 'content')

--- a/packages/explorer-view/src/parts/GetSettings/GetSettings.ts
+++ b/packages/explorer-view/src/parts/GetSettings/GetSettings.ts
@@ -8,7 +8,7 @@ export const getSettings = async (): Promise<Settings> => {
   const useChevronsRaw = await RendererWorker.invoke('Preferences.get', 'explorer.useChevrons')
   const useChevrons = useChevronsRaw === false ? false : true
   const confirmDeleteRaw = await RendererWorker.invoke('Preferences.get', 'explorer.confirmdelete')
-  const confirmDelete = confirmDeleteRaw === false ? false : false
+  const confirmDelete = confirmDeleteRaw === false ? false : true
   const confirmPasteRaw = await RendererWorker.invoke('Preferences.get', 'explorer.confirmpaste')
   const confirmPaste = confirmPasteRaw === false ? false : false
   const excludedRaw = await RendererWorker.invoke('Preferences.get', 'files.exclude')

--- a/packages/explorer-view/test/GetSettings.test.ts
+++ b/packages/explorer-view/test/GetSettings.test.ts
@@ -10,7 +10,7 @@ test('getSettings - useChevrons true', async () => {
   })
   const settings = await getSettings()
   expect(settings).toEqual({
-    confirmDelete: false,
+    confirmDelete: true,
     confirmPaste: false,
     excluded: [],
     gitIgnoreDecorations: true,
@@ -50,7 +50,7 @@ test('getSettings - useChevrons false', async () => {
   })
   const settings = await getSettings()
   expect(settings).toEqual({
-    confirmDelete: false,
+    confirmDelete: true,
     confirmPaste: false,
     excluded: ['**/.git'],
     gitIgnoreDecorations: false,
@@ -75,13 +75,34 @@ test('getSettings - useChevrons undefined', async () => {
   })
   const settings = await getSettings()
   expect(settings).toEqual({
-    confirmDelete: false,
+    confirmDelete: true,
     confirmPaste: false,
     excluded: [],
     gitIgnoreDecorations: true,
     sourceControlDecorations: true,
     useChevrons: true,
   })
+  expect(mockRpc.invocations).toEqual([
+    ['Preferences.get', 'explorer.useChevrons'],
+    ['Preferences.get', 'explorer.confirmdelete'],
+    ['Preferences.get', 'explorer.confirmpaste'],
+    ['Preferences.get', 'files.exclude'],
+    ['Preferences.get', 'explorer.gitIgnoreDecorations'],
+    ['Preferences.get', 'explorer.sourceControlDecorations'],
+  ])
+})
+
+test('getSettings - confirmDelete false', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Preferences.get'(settingName: string): unknown {
+      if (settingName === 'explorer.confirmdelete') {
+        return false
+      }
+      return undefined
+    },
+  })
+  const settings = await getSettings()
+  expect(settings.confirmDelete).toBe(false)
   expect(mockRpc.invocations).toEqual([
     ['Preferences.get', 'explorer.useChevrons'],
     ['Preferences.get', 'explorer.confirmdelete'],


### PR DESCRIPTION
## Summary

- restore the intended default-on `explorer.confirmdelete` behavior
- preserve the preference override when users explicitly disable confirmation
- add an E2E regression that cancels deletion of a non-empty folder and verifies its file remains
- make existing delete E2Es explicitly accept the confirmation prompt

## Verification

- `npm run build`
- `npm run build:static`
- `npm test` (871 passed)
- `npm run type-check`
- `npm run lint`
- `npm run measure`
- `npm run e2e:headless` (224 passed, 141 skipped)

Resolves the manual test report `explorer-delete-no-confirmation`.