### PR TITLE
fix: preserve files on explorer paste collisions

### DIFF
--- a/packages/e2e/src/viewlet.explorer-copy-paste-collision-preserves-files.ts
+++ b/packages/e2e/src/viewlet.explorer-copy-paste-collision-preserves-files.ts
@@ -1,0 +1,33 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-copy-paste-collision-preserves-files'
+
+export const test: Test = async ({ ClipBoard, Explorer, FileSystem, Workspace }) => {
+  await ClipBoard.enableMemoryClipBoard()
+  const tmpDir = await FileSystem.getTmpDir({ scheme: 'file' })
+  const sourcePath = `${tmpDir}/source2.txt`
+  const existingTargetPath = `${tmpDir}/target/source2.txt`
+  const copiedPath = `${tmpDir}/target/source2 copy.txt`
+  await FileSystem.writeFile(sourcePath, 'source two')
+  await FileSystem.mkdir(`${tmpDir}/target`)
+  await FileSystem.writeFile(existingTargetPath, 'destination two')
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(1)
+  await Explorer.handleCopy()
+  await Explorer.focusIndex(0)
+  await Explorer.handlePaste()
+
+  const sourceContent = await FileSystem.readFile(sourcePath)
+  const existingTargetContent = await FileSystem.readFile(existingTargetPath)
+  const copiedContent = await FileSystem.readFile(copiedPath)
+  if (sourceContent !== 'source two') {
+    throw new Error(`Expected source file to be preserved, got ${JSON.stringify(sourceContent)}`)
+  }
+  if (existingTargetContent !== 'destination two') {
+    throw new Error(`Expected existing destination file to be preserved, got ${JSON.stringify(existingTargetContent)}`)
+  }
+  if (copiedContent !== 'source two') {
+    throw new Error(`Expected renamed copy to contain source content, got ${JSON.stringify(copiedContent)}`)
+  }
+}

--- a/packages/explorer-view/src/parts/GetFileOperationsCopy/GetFileOperationsCopy.ts
+++ b/packages/explorer-view/src/parts/GetFileOperationsCopy/GetFileOperationsCopy.ts
@@ -3,31 +3,20 @@ import * as FileOperationType from '../FileOperationType/FileOperationType.ts'
 import { generateUniqueName } from '../GenerateUniqueName/GenerateUniqueName.ts'
 import * as Path from '../Path/Path.ts'
 
-export const getFileOperationsCopy = (
-  root: string,
-  existingUris: readonly string[],
-  files: readonly string[],
-  focusedUri: string,
-): readonly FileOperation[] => {
+export const getFileOperationsCopy = (targetUri: string, existingUris: readonly string[], files: readonly string[]): readonly FileOperation[] => {
   const operations: FileOperation[] = []
+  const reservedUris = [...existingUris]
 
   for (const file of files) {
     const baseName = Path.getBaseName('/', file)
-    if (existingUris.includes(file)) {
-      operations.push({
-        from: file,
-        path: Path.join2(focusedUri, baseName),
-        type: FileOperationType.Copy,
-      })
-    } else {
-      const uniqueName = generateUniqueName(baseName, existingUris, root)
-      const newUri = Path.join2(root, uniqueName)
-      operations.push({
-        from: file, // TODO ensure file is uri
-        path: newUri,
-        type: FileOperationType.Copy,
-      })
-    }
+    const uniqueName = generateUniqueName(baseName, reservedUris, targetUri)
+    const newUri = Path.join2(targetUri, uniqueName)
+    operations.push({
+      from: file,
+      path: newUri,
+      type: FileOperationType.Copy,
+    })
+    reservedUris.push(newUri)
   }
   return operations
 }

--- a/packages/explorer-view/src/parts/HandlePasteCopy/HandlePasteCopy.ts
+++ b/packages/explorer-view/src/parts/HandlePasteCopy/HandlePasteCopy.ts
@@ -2,8 +2,11 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import type { NativeFilesResult } from '../NativeFilesResult/NativeFilesResult.ts'
 import * as AdjustScrollAfterPaste from '../AdjustScrollAfterPaste/AdjustScrollAfterPaste.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
+import * as FileSystem from '../FileSystem/FileSystem.ts'
 import { getFileOperationsCopy } from '../GetFileOperationsCopy/GetFileOperationsCopy.ts'
 import { getIndex } from '../GetIndex/GetIndex.ts'
+import { getParentFolder } from '../GetParentFolder/GetParentFolder.ts'
+import * as Path from '../Path/Path.ts'
 import { refresh } from '../Refresh/Refresh.ts'
 
 export const handlePasteCopy = async (state: ExplorerState, nativeFiles: NativeFilesResult): Promise<ExplorerState> => {
@@ -14,10 +17,11 @@ export const handlePasteCopy = async (state: ExplorerState, nativeFiles: NativeF
   // TODO what if folder is big and it takes a long time
 
   // TODO use file operations and bulk edit
-  const { focusedIndex, items, root } = state
-  const focusedUri = items[focusedIndex]?.path || root
-  const existingUris = items.map((item) => item.path)
-  const operations = getFileOperationsCopy(root, existingUris, nativeFiles.files, focusedUri)
+  const { focusedIndex, items, pathSeparator, root } = state
+  const targetUri = getParentFolder(items, focusedIndex, root, pathSeparator)
+  const targetDirents = await FileSystem.readDirWithFileTypes(targetUri)
+  const existingUris = targetDirents.map((dirent) => Path.join2(targetUri, dirent.name))
+  const operations = getFileOperationsCopy(targetUri, existingUris, nativeFiles.files)
   // TODO handle error?
   await ApplyFileOperations.applyFileOperations(operations)
 

--- a/packages/explorer-view/test/GetFileOperationsCopy.test.ts
+++ b/packages/explorer-view/test/GetFileOperationsCopy.test.ts
@@ -7,7 +7,7 @@ test('getFileOperationsCopy - no conflicts', () => {
   const existingUris = ['/test/existing.txt']
   const files = ['/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file.txt', type: FileOperationType.Copy }])
 })
 
@@ -16,7 +16,7 @@ test('getFileOperationsCopy - single conflict', () => {
   const existingUris = ['/test/file.txt']
   const files = ['/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file copy.txt', type: FileOperationType.Copy }])
 })
 
@@ -25,7 +25,7 @@ test('getFileOperationsCopy - multiple conflicts', () => {
   const existingUris = ['/test/file.txt', '/test/file copy.txt']
   const files = ['/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file copy 1.txt', type: FileOperationType.Copy }])
 })
 
@@ -34,7 +34,7 @@ test('getFileOperationsCopy - multiple numbered conflicts', () => {
   const existingUris = ['/test/file.txt', '/test/file copy.txt', '/test/file copy 1.txt', '/test/file copy 2.txt']
   const files = ['/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file copy 3.txt', type: FileOperationType.Copy }])
 })
 
@@ -43,7 +43,7 @@ test('getFileOperationsCopy - file without extension', () => {
   const existingUris = ['/test/README']
   const files = ['/source/README']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/README', path: '/test/README copy', type: FileOperationType.Copy }])
 })
 
@@ -52,7 +52,7 @@ test('getFileOperationsCopy - file without extension multiple conflicts', () => 
   const existingUris = ['/test/README', '/test/README copy', '/test/README copy 1']
   const files = ['/source/README']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/README', path: '/test/README copy 2', type: FileOperationType.Copy }])
 })
 
@@ -61,7 +61,7 @@ test('getFileOperationsCopy - multiple files with conflicts', () => {
   const existingUris = ['/test/file1.txt', '/test/file2.txt']
   const files = ['/source/file1.txt', '/source/file2.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([
     { from: '/source/file1.txt', path: '/test/file1 copy.txt', type: FileOperationType.Copy },
     { from: '/source/file2.txt', path: '/test/file2 copy.txt', type: FileOperationType.Copy },
@@ -73,16 +73,14 @@ test('getFileOperationsCopy - empty existingUris', () => {
   const existingUris: readonly string[] = []
   const files = ['/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([{ from: '/source/file.txt', path: '/test/file.txt', type: FileOperationType.Copy }])
 })
 
 test('getFileOperationsCopy - copies workspace file into focused folder', () => {
-  const root = '/test'
-  const existingUris = ['/test/source', '/test/source/file.txt', '/test/target']
   const files = ['/test/source/file.txt']
 
-  const result = getFileOperationsCopy(root, existingUris, files, '/test/target')
+  const result = getFileOperationsCopy('/test/target', [], files)
   expect(result).toEqual([{ from: '/test/source/file.txt', path: '/test/target/file.txt', type: FileOperationType.Copy }])
 })
 
@@ -91,6 +89,17 @@ test('getFileOperationsCopy - empty files', () => {
   const existingUris = ['/test/existing.txt']
   const files: readonly string[] = []
 
-  const result = getFileOperationsCopy(root, existingUris, files, root)
+  const result = getFileOperationsCopy(root, existingUris, files)
   expect(result).toEqual([])
+})
+
+test('getFileOperationsCopy - reserves names created by earlier operations', () => {
+  const files = ['/source-a/file.txt', '/source-b/file.txt']
+
+  const result = getFileOperationsCopy('/test', [], files)
+
+  expect(result).toEqual([
+    { from: '/source-a/file.txt', path: '/test/file.txt', type: FileOperationType.Copy },
+    { from: '/source-b/file.txt', path: '/test/file copy.txt', type: FileOperationType.Copy },
+  ])
 })

--- a/packages/explorer-view/test/HandlePaste.test.ts
+++ b/packages/explorer-view/test/HandlePaste.test.ts
@@ -53,6 +53,7 @@ test('should handle paste with copy type', async () => {
   expect(result).toHaveProperty('icons')
   expect(mockRpc.invocations).toEqual([
     ['ClipBoard.readNativeFiles'],
+    ['FileSystem.readDirWithFileTypes', '/'],
     ['FileSystem.copy', '/source/file1.txt', '/file1.txt'],
     ['FileSystem.copy', '/source/file2.txt', '/file2.txt'],
     ['FileSystem.readDirWithFileTypes', '/'],
@@ -91,6 +92,7 @@ test('should handle paste with cut type', async () => {
   expect(result).toHaveProperty('icons')
   expect(mockRpc.invocations).toEqual([
     ['ClipBoard.readNativeFiles'],
+    ['FileSystem.readDirWithFileTypes', '/'],
     ['FileSystem.copy', '/source/file1.txt', '/file1.txt'],
     ['FileSystem.copy', '/source/file2.txt', '/file2.txt'],
     ['FileSystem.readDirWithFileTypes', '/'],
@@ -128,6 +130,7 @@ test('should handle paste with multiple files', async () => {
   expect(result).toHaveProperty('icons')
   expect(mockRpc.invocations).toEqual([
     ['ClipBoard.readNativeFiles'],
+    ['FileSystem.readDirWithFileTypes', '/'],
     ['FileSystem.copy', '/source/file1.txt', '/file1.txt'],
     ['FileSystem.copy', '/source/file2.txt', '/file2.txt'],
     ['FileSystem.copy', '/source/folder1', '/folder1'],
@@ -164,7 +167,11 @@ test('should handle paste with empty files array', async () => {
   expect(result).toBeDefined()
   expect(result).toHaveProperty('items')
   expect(result).toHaveProperty('icons')
-  expect(mockRpc.invocations).toEqual([['ClipBoard.readNativeFiles'], ['FileSystem.readDirWithFileTypes', '/']])
+  expect(mockRpc.invocations).toEqual([
+    ['ClipBoard.readNativeFiles'],
+    ['FileSystem.readDirWithFileTypes', '/'],
+    ['FileSystem.readDirWithFileTypes', '/'],
+  ])
 })
 
 test('should preserve state properties when handling paste', async () => {
@@ -198,6 +205,7 @@ test('should preserve state properties when handling paste', async () => {
   expect(result).toHaveProperty('icons')
   expect(mockRpc.invocations).toEqual([
     ['ClipBoard.readNativeFiles'],
+    ['FileSystem.readDirWithFileTypes', '/'],
     ['FileSystem.copy', '/source/file.txt', '/file.txt'],
     ['FileSystem.readDirWithFileTypes', '/'],
   ])

--- a/packages/explorer-view/test/HandlePasteCopy.test.ts
+++ b/packages/explorer-view/test/HandlePasteCopy.test.ts
@@ -6,6 +6,7 @@ import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import { handlePasteCopy } from '../src/parts/HandlePasteCopy/HandlePasteCopy.ts'
 
 test('should focus on first newly created file after paste copy', async () => {
+  let readCount = 0
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.copy'() {
       return undefined
@@ -14,10 +15,13 @@ test('should focus on first newly created file after paste copy', async () => {
       return '/'
     },
     'FileSystem.readDirWithFileTypes'() {
-      return [
-        { name: 'index.js', type: DirentType.File },
-        { name: 'index copy.js', type: DirentType.File },
-      ]
+      readCount++
+      return readCount === 1
+        ? [{ name: 'index.js', type: DirentType.File }]
+        : [
+            { name: 'index.js', type: DirentType.File },
+            { name: 'index copy.js', type: DirentType.File },
+          ]
     },
     'IconTheme.getIcons'() {
       return ['', '']
@@ -48,12 +52,14 @@ test('should focus on first newly created file after paste copy', async () => {
   expect(focusedItem.path).toBe('/test/index copy.js')
   expect(result.focused).toBe(true)
   expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/test'],
     ['FileSystem.copy', '/source/index.js', '/test/index copy.js'],
     ['FileSystem.readDirWithFileTypes', '/test'],
   ])
 })
 
 test('should handle paste copy with multiple files and focus on first', async () => {
+  let readCount = 0
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.copy'() {
       return undefined
@@ -62,12 +68,18 @@ test('should handle paste copy with multiple files and focus on first', async ()
       return '/'
     },
     'FileSystem.readDirWithFileTypes'() {
-      return [
-        { name: 'file1.txt', type: DirentType.File },
-        { name: 'file1 copy.txt', type: DirentType.File },
-        { name: 'file2.txt', type: DirentType.File },
-        { name: 'file2 copy.txt', type: DirentType.File },
-      ]
+      readCount++
+      return readCount === 1
+        ? [
+            { name: 'file1.txt', type: DirentType.File },
+            { name: 'file2.txt', type: DirentType.File },
+          ]
+        : [
+            { name: 'file1.txt', type: DirentType.File },
+            { name: 'file1 copy.txt', type: DirentType.File },
+            { name: 'file2.txt', type: DirentType.File },
+            { name: 'file2 copy.txt', type: DirentType.File },
+          ]
     },
     'IconTheme.getIcons'() {
       return ['', '', '', '']
@@ -101,6 +113,7 @@ test('should handle paste copy with multiple files and focus on first', async ()
   expect(focusedItem.path).toBe('/test/file1 copy.txt')
   expect(result.focused).toBe(true)
   expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/test'],
     ['FileSystem.copy', '/source/file1.txt', '/test/file1 copy.txt'],
     ['FileSystem.copy', '/source/file2.txt', '/test/file2 copy.txt'],
     ['FileSystem.readDirWithFileTypes', '/test'],
@@ -141,5 +154,54 @@ test('should handle paste copy with empty files array', async () => {
   expect(result).toBeDefined()
   expect(result.items).toHaveLength(0)
   expect(result.focusedIndex).toBe(0)
-  expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/test']])
+  expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/test'],
+    ['FileSystem.readDirWithFileTypes', '/test'],
+  ])
+})
+
+test('should preserve existing file when pasting into collapsed folder', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.copy'() {},
+    'FileSystem.getPathSeparator'() {
+      return '/'
+    },
+    'FileSystem.readDirWithFileTypes'(path: string) {
+      if (path === '/test/target') {
+        return [{ name: 'file.txt', type: DirentType.File }]
+      }
+      return [
+        { name: 'file.txt', type: DirentType.File },
+        { name: 'target', type: DirentType.Directory },
+      ]
+    },
+    'IconTheme.getIcons'() {
+      return ['', '']
+    },
+    'Preferences.get'() {
+      return false
+    },
+  })
+  const initialState: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 1,
+    items: [
+      { depth: 0, name: 'file.txt', path: '/test/file.txt', selected: false, type: DirentType.File },
+      { depth: 0, name: 'target', path: '/test/target', selected: false, type: DirentType.Directory },
+    ],
+    root: '/test',
+  }
+  const nativeFiles = {
+    files: ['/test/file.txt'],
+    source: 'gnomeCopiedFiles' as const,
+    type: 'copy' as const,
+  }
+
+  await handlePasteCopy(initialState, nativeFiles)
+
+  expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/test/target'],
+    ['FileSystem.copy', '/test/file.txt', '/test/target/file copy.txt'],
+    ['FileSystem.readDirWithFileTypes', '/test'],
+  ])
 })


### PR DESCRIPTION
## Summary

- inspect the actual target directory before planning Explorer copy operations, including collapsed folders
- generate and reserve unique destination names instead of overwriting existing entries
- add unit coverage and an end-to-end regression that verifies the source, existing destination, and renamed copy contents

## Verification

- `npm run build`
- `npm run build:static`
- `npm test` (223 suites passed, 873 tests passed)
- `npm run type-check`
- `npm run lint`
- `npx test-with-playwright --only-extension=. --test-path=. --headless --reuse-page --filter=explorer-copy-paste-collision-preserves-files` (from `packages/e2e`)

Together with #1744, resolves the manual test report `explorer-paste-overwrites-existing-file`.