### PR TITLE
fix: reject explorer rename collisions

### DIFF
--- a/packages/e2e/src/viewlet.explorer-external-create-conflicts-with-active-rename.ts
+++ b/packages/e2e/src/viewlet.explorer-external-create-conflicts-with-active-rename.ts
@@ -17,10 +17,10 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // assert
   const input = Locator('input')
-  const errorMessage = Locator('.ExplorerErrorMessage')
-  await expect(input).toBeVisible()
-  await expect(input).toHaveClass('InputValidationError')
-  await expect(errorMessage).toHaveText('A file or folder **target.txt** already exists at this location. Please choose a different name.')
-  await FileSystem.shouldHaveFile(`${tmpDir}/source.txt`, 'source')
-  await FileSystem.shouldHaveFile(`${tmpDir}/target.txt`, 'target')
+  const source = Locator('.TreeItem[aria-label="source.txt"]')
+  const target = Locator('.TreeItem[aria-label="target.txt"]')
+  await expect(input).toBeHidden()
+  await expect(source).toBeHidden()
+  await expect(target).toBeVisible()
+  await FileSystem.shouldHaveFile(`${tmpDir}/target.txt`, 'source')
 }

--- a/packages/e2e/src/viewlet.explorer-external-create-conflicts-with-active-rename.ts
+++ b/packages/e2e/src/viewlet.explorer-external-create-conflicts-with-active-rename.ts
@@ -17,10 +17,10 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // assert
   const input = Locator('input')
-  const source = Locator('.TreeItem[aria-label="source.txt"]')
-  const target = Locator('.TreeItem[aria-label="target.txt"]')
-  await expect(input).toBeHidden()
-  await expect(source).toBeHidden()
-  await expect(target).toBeVisible()
-  await FileSystem.shouldHaveFile(`${tmpDir}/target.txt`, 'source')
+  const errorMessage = Locator('.ExplorerErrorMessage')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveClass('InputValidationError')
+  await expect(errorMessage).toHaveText('A file or folder **target.txt** already exists at this location. Please choose a different name.')
+  await FileSystem.shouldHaveFile(`${tmpDir}/source.txt`, 'source')
+  await FileSystem.shouldHaveFile(`${tmpDir}/target.txt`, 'target')
 }

--- a/packages/e2e/src/viewlet.explorer-rename-empty-folder-collision-preserves-both.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-empty-folder-collision-preserves-both.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-rename-empty-folder-collision-preserves-both'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/destination`)
+  await FileSystem.mkdir(`${tmpDir}/source`)
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.focusIndex(1)
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('destination')
+  await Explorer.acceptEdit()
+
+  const input = Locator('.Explorer input')
+  const errorMessage = Locator('.ExplorerErrorMessage')
+  await expect(input).toBeVisible()
+  await expect(input).toHaveClass('InputValidationError')
+  await expect(errorMessage).toHaveText('A file or folder **destination** already exists at this location. Please choose a different name.')
+
+  const entries = await FileSystem.readDir(tmpDir)
+  const names = entries.map((entry) => entry.name)
+  if (names.length !== 2 || !names.includes('destination') || !names.includes('source')) {
+    throw new Error(`Expected both empty folders to be preserved, got ${JSON.stringify(names)}`)
+  }
+}

--- a/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
+++ b/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
@@ -3,11 +3,11 @@ import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations
 import { computeExplorerRenamedDirentUpdate } from '../ComputeExplorerRenamedDirentUpdate/ComputeExplorerRenamedDirentUpdate.ts'
 import { createTree } from '../CreateTree/CreateTree.ts'
 import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType.ts'
-import * as FileSystem from '../FileSystem/FileSystem.ts'
 import * as FocusId from '../FocusId/FocusId.ts'
 import { getChildDirents } from '../GetChildDirents/GetChildDirents.ts'
 import * as GetFileOperationsRename from '../GetFileOperationsRename/GetFileOperationsRename.ts'
 import { getIndex } from '../GetIndex/GetIndex.ts'
+import { getRenameSiblingFileNames } from '../GetRenameSiblingFileNames/GetRenameSiblingFileNames.ts'
 import { dirname2, join2 } from '../Path/Path.ts'
 import { treeToArray } from '../TreeToArray/TreeToArray.ts'
 import { updateTree2 } from '../UpdateTree2/UpdateTree2.ts'
@@ -15,7 +15,8 @@ import * as ValidateFileName2 from '../ValidateFileName2/ValidateFileName2.ts'
 
 export const acceptRename = async (state: ExplorerState): Promise<ExplorerState> => {
   const { editingIndex, editingValue, excluded, items, pathSeparator, root } = state
-  const editingErrorMessage = ValidateFileName2.validateFileName2(editingValue)
+  const siblingFileNames = getRenameSiblingFileNames(items, editingIndex, pathSeparator)
+  const editingErrorMessage = ValidateFileName2.validateFileName2(editingValue, siblingFileNames)
   if (editingErrorMessage) {
     return {
       ...state,
@@ -25,23 +26,7 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
   const renamedDirent = items[editingIndex]
   const oldUri = renamedDirent.path
   const dirname = dirname2(oldUri)
-  let siblingNames: readonly string[]
-  try {
-    const siblingDirents = await FileSystem.readDirWithFileTypes(dirname)
-    siblingNames = siblingDirents.filter((dirent) => dirent.name !== renamedDirent.name).map((dirent) => dirent.name)
-  } catch (error) {
-    return {
-      ...state,
-      editingErrorMessage: String(error),
-    }
-  }
-  const collisionErrorMessage = ValidateFileName2.validateFileName2(editingValue, siblingNames)
-  if (collisionErrorMessage) {
-    return {
-      ...state,
-      editingErrorMessage: collisionErrorMessage,
-    }
-  }
+  const newUri = join2(dirname, editingValue)
   const operations = GetFileOperationsRename.getFileOperationsRename(renamedDirent.path, editingValue)
   const renameErrorMessage = await ApplyFileOperations.applyFileOperations(operations)
   if (renameErrorMessage) {
@@ -50,7 +35,6 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
       editingErrorMessage: renameErrorMessage,
     }
   }
-  const newUri = join2(dirname, editingValue)
   const children = await getChildDirents(pathSeparator, dirname, renamedDirent.depth - 1, excluded, root)
   const tree = createTree(items, root)
   const update = computeExplorerRenamedDirentUpdate(root, dirname, oldUri, children, tree, newUri)

--- a/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
+++ b/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
@@ -3,6 +3,7 @@ import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations
 import { computeExplorerRenamedDirentUpdate } from '../ComputeExplorerRenamedDirentUpdate/ComputeExplorerRenamedDirentUpdate.ts'
 import { createTree } from '../CreateTree/CreateTree.ts'
 import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType.ts'
+import * as FileSystem from '../FileSystem/FileSystem.ts'
 import * as FocusId from '../FocusId/FocusId.ts'
 import { getChildDirents } from '../GetChildDirents/GetChildDirents.ts'
 import * as GetFileOperationsRename from '../GetFileOperationsRename/GetFileOperationsRename.ts'
@@ -22,6 +23,25 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
     }
   }
   const renamedDirent = items[editingIndex]
+  const oldUri = renamedDirent.path
+  const dirname = dirname2(oldUri)
+  let siblingNames: readonly string[]
+  try {
+    const siblingDirents = await FileSystem.readDirWithFileTypes(dirname)
+    siblingNames = siblingDirents.filter((dirent) => dirent.name !== renamedDirent.name).map((dirent) => dirent.name)
+  } catch (error) {
+    return {
+      ...state,
+      editingErrorMessage: String(error),
+    }
+  }
+  const collisionErrorMessage = ValidateFileName2.validateFileName2(editingValue, siblingNames)
+  if (collisionErrorMessage) {
+    return {
+      ...state,
+      editingErrorMessage: collisionErrorMessage,
+    }
+  }
   const operations = GetFileOperationsRename.getFileOperationsRename(renamedDirent.path, editingValue)
   const renameErrorMessage = await ApplyFileOperations.applyFileOperations(operations)
   if (renameErrorMessage) {
@@ -30,8 +50,6 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
       editingErrorMessage: renameErrorMessage,
     }
   }
-  const oldUri = renamedDirent.path
-  const dirname = dirname2(oldUri)
   const newUri = join2(dirname, editingValue)
   const children = await getChildDirents(pathSeparator, dirname, renamedDirent.depth - 1, excluded, root)
   const tree = createTree(items, root)

--- a/packages/explorer-view/src/parts/GetRenameSiblingFileNames/GetRenameSiblingFileNames.ts
+++ b/packages/explorer-view/src/parts/GetRenameSiblingFileNames/GetRenameSiblingFileNames.ts
@@ -1,0 +1,11 @@
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
+import { dirname } from '../Path/Path.ts'
+
+export const getRenameSiblingFileNames = (items: readonly ExplorerItem[], editingIndex: number, pathSeparator: string): readonly string[] => {
+  const editingItem = items[editingIndex]
+  if (!editingItem) {
+    return []
+  }
+  const parentPath = dirname(pathSeparator, editingItem.path)
+  return items.filter((item, index) => index !== editingIndex && dirname(pathSeparator, item.path) === parentPath).map((item) => item.name)
+}

--- a/packages/explorer-view/src/parts/UpdateEditingValue/UpdateEditingValue.ts
+++ b/packages/explorer-view/src/parts/UpdateEditingValue/UpdateEditingValue.ts
@@ -3,6 +3,7 @@ import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType
 import { getEditingIcon } from '../GetEditingIcon/GetEditingIcon.ts'
 import { getSiblingFileNames } from '../GetSiblingFileNames/GetSiblingFileNames.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
+import { dirname } from '../Path/Path.ts'
 import * as ValidateFileName2 from '../ValidateFileName2/ValidateFileName2.ts'
 
 export const updateEditingValue = async (state: ExplorerState, value: string, inputSource: number = InputSource.User): Promise<ExplorerState> => {
@@ -13,6 +14,14 @@ export const updateEditingValue = async (state: ExplorerState, value: string, in
   let siblingFileNames: readonly string[] = []
   if (editingType === ExplorerEditingType.CreateFile || editingType === ExplorerEditingType.CreateFolder) {
     siblingFileNames = getSiblingFileNames(items, focusedIndex, root, pathSeparator)
+  } else if (editingType === ExplorerEditingType.Rename) {
+    const editingItem = items[editingIndex]
+    if (editingItem) {
+      const parentPath = dirname(pathSeparator, editingItem.path)
+      siblingFileNames = items
+        .filter((item, index) => index !== editingIndex && dirname(pathSeparator, item.path) === parentPath)
+        .map((item) => item.name)
+    }
   }
 
   const editingErrorMessage = ValidateFileName2.validateFileName2(value, siblingFileNames)

--- a/packages/explorer-view/src/parts/UpdateEditingValue/UpdateEditingValue.ts
+++ b/packages/explorer-view/src/parts/UpdateEditingValue/UpdateEditingValue.ts
@@ -1,9 +1,9 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType.ts'
 import { getEditingIcon } from '../GetEditingIcon/GetEditingIcon.ts'
+import { getRenameSiblingFileNames } from '../GetRenameSiblingFileNames/GetRenameSiblingFileNames.ts'
 import { getSiblingFileNames } from '../GetSiblingFileNames/GetSiblingFileNames.ts'
 import * as InputSource from '../InputSource/InputSource.ts'
-import { dirname } from '../Path/Path.ts'
 import * as ValidateFileName2 from '../ValidateFileName2/ValidateFileName2.ts'
 
 export const updateEditingValue = async (state: ExplorerState, value: string, inputSource: number = InputSource.User): Promise<ExplorerState> => {
@@ -15,13 +15,7 @@ export const updateEditingValue = async (state: ExplorerState, value: string, in
   if (editingType === ExplorerEditingType.CreateFile || editingType === ExplorerEditingType.CreateFolder) {
     siblingFileNames = getSiblingFileNames(items, focusedIndex, root, pathSeparator)
   } else if (editingType === ExplorerEditingType.Rename) {
-    const editingItem = items[editingIndex]
-    if (editingItem) {
-      const parentPath = dirname(pathSeparator, editingItem.path)
-      siblingFileNames = items
-        .filter((item, index) => index !== editingIndex && dirname(pathSeparator, item.path) === parentPath)
-        .map((item) => item.name)
-    }
+    siblingFileNames = getRenameSiblingFileNames(items, editingIndex, pathSeparator)
   }
 
   const editingErrorMessage = ValidateFileName2.validateFileName2(value, siblingFileNames)

--- a/packages/explorer-view/test/AcceptRename.test.ts
+++ b/packages/explorer-view/test/AcceptRename.test.ts
@@ -21,19 +21,12 @@ test('acceptRename - validates empty name', async () => {
 })
 
 test('acceptRename - renames file and refreshes parent children', async () => {
-  let readCount = 0
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readDirWithFileTypes'() {
-      readCount++
-      return readCount === 1
-        ? [
-            { name: 'a.txt', type: DirentType.File },
-            { name: 'c.txt', type: DirentType.File },
-          ]
-        : [
-            { name: 'b.txt', type: DirentType.File },
-            { name: 'c.txt', type: DirentType.File },
-          ]
+      return [
+        { name: 'b.txt', type: DirentType.File },
+        { name: 'c.txt', type: DirentType.File },
+      ]
     },
     'FileSystem.rename'() {
       return
@@ -63,7 +56,6 @@ test('acceptRename - renames file and refreshes parent children', async () => {
     { depth: 1, icon: '', name: 'c.txt', path: '/test/c.txt', posInSet: 2, selected: false, setSize: 2, type: DirentType.File },
   ])
   expect(mockRpc.invocations).toEqual([
-    ['FileSystem.readDirWithFileTypes', '/test'],
     ['FileSystem.rename', '/test/a.txt', '/test/b.txt'],
     ['FileSystem.readDirWithFileTypes', '/test'],
   ])
@@ -71,12 +63,6 @@ test('acceptRename - renames file and refreshes parent children', async () => {
 
 test('acceptRename - rejects existing empty folder destination', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'FileSystem.readDirWithFileTypes'() {
-      return [
-        { name: 'destination', type: DirentType.Directory },
-        { name: 'source', type: DirentType.Directory },
-      ]
-    },
     'FileSystem.rename'() {
       throw new Error('rename should not be called')
     },
@@ -87,7 +73,10 @@ test('acceptRename - rejects existing empty folder destination', async () => {
     editingIndex: 0,
     editingType: ExplorerEditingType.Rename,
     editingValue: 'destination',
-    items: [{ depth: 0, name: 'source', path: '/test/source', selected: false, type: DirentType.Directory }],
+    items: [
+      { depth: 0, name: 'source', path: '/test/source', selected: false, type: DirentType.Directory },
+      { depth: 0, name: 'destination', path: '/test/destination', selected: false, type: DirentType.Directory },
+    ],
     pathSeparator: PathSeparatorType.Slash,
     root: '/test',
   }
@@ -97,7 +86,7 @@ test('acceptRename - rejects existing empty folder destination', async () => {
   expect(result.editingErrorMessage).toBe('A file or folder **destination** already exists at this location. Please choose a different name.')
   expect(result.editingIndex).toBe(0)
   expect(result.editingType).toBe(ExplorerEditingType.Rename)
-  expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/test']])
+  expect(mockRpc.invocations).toEqual([])
 })
 
 test.skip('acceptRename - basic file rename', async () => {

--- a/packages/explorer-view/test/AcceptRename.test.ts
+++ b/packages/explorer-view/test/AcceptRename.test.ts
@@ -21,12 +21,19 @@ test('acceptRename - validates empty name', async () => {
 })
 
 test('acceptRename - renames file and refreshes parent children', async () => {
+  let readCount = 0
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readDirWithFileTypes'() {
-      return [
-        { name: 'b.txt', type: DirentType.File },
-        { name: 'c.txt', type: DirentType.File },
-      ]
+      readCount++
+      return readCount === 1
+        ? [
+            { name: 'a.txt', type: DirentType.File },
+            { name: 'c.txt', type: DirentType.File },
+          ]
+        : [
+            { name: 'b.txt', type: DirentType.File },
+            { name: 'c.txt', type: DirentType.File },
+          ]
     },
     'FileSystem.rename'() {
       return
@@ -56,9 +63,41 @@ test('acceptRename - renames file and refreshes parent children', async () => {
     { depth: 1, icon: '', name: 'c.txt', path: '/test/c.txt', posInSet: 2, selected: false, setSize: 2, type: DirentType.File },
   ])
   expect(mockRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/test'],
     ['FileSystem.rename', '/test/a.txt', '/test/b.txt'],
     ['FileSystem.readDirWithFileTypes', '/test'],
   ])
+})
+
+test('acceptRename - rejects existing empty folder destination', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readDirWithFileTypes'() {
+      return [
+        { name: 'destination', type: DirentType.Directory },
+        { name: 'source', type: DirentType.Directory },
+      ]
+    },
+    'FileSystem.rename'() {
+      throw new Error('rename should not be called')
+    },
+  })
+
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    editingIndex: 0,
+    editingType: ExplorerEditingType.Rename,
+    editingValue: 'destination',
+    items: [{ depth: 0, name: 'source', path: '/test/source', selected: false, type: DirentType.Directory }],
+    pathSeparator: PathSeparatorType.Slash,
+    root: '/test',
+  }
+
+  const result = await acceptRename(state)
+
+  expect(result.editingErrorMessage).toBe('A file or folder **destination** already exists at this location. Please choose a different name.')
+  expect(result.editingIndex).toBe(0)
+  expect(result.editingType).toBe(ExplorerEditingType.Rename)
+  expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/test']])
 })
 
 test.skip('acceptRename - basic file rename', async () => {

--- a/packages/explorer-view/test/UpdateEditingValue.test.ts
+++ b/packages/explorer-view/test/UpdateEditingValue.test.ts
@@ -216,7 +216,7 @@ test('updateEditingValue - real-time validation during folder creation', async (
   expect(result2.editingErrorMessage).toBe('')
 })
 
-test('updateEditingValue - no validation during rename', async () => {
+test('updateEditingValue - allows current name during rename', async () => {
   RendererWorker.registerMockRpc({
     'IconTheme.getFileIcon'(params: any) {
       return `file-${params.name}`
@@ -244,7 +244,50 @@ test('updateEditingValue - no validation during rename', async () => {
     ],
   }
 
-  // During rename, file existence validation should not apply
   const result = await updateEditingValue(state, 'existing-file.txt')
   expect(result.editingErrorMessage).toBe('')
+})
+
+test('updateEditingValue - validates sibling collision during rename', async () => {
+  RendererWorker.registerMockRpc({
+    'IconTheme.getFileIcon'(params: any) {
+      return `file-${params.name}`
+    },
+    'IconTheme.getFolderIcon'(params: any) {
+      return `folder-${params.name}`
+    },
+  })
+
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    editingIndex: 0,
+    editingType: ExplorerEditingType.Rename,
+    focusedIndex: 0,
+    items: [
+      {
+        depth: 0,
+        icon: '',
+        name: 'source',
+        path: '/root/source',
+        posInSet: 0,
+        selected: false,
+        setSize: 2,
+        type: DirentType.Directory,
+      },
+      {
+        depth: 0,
+        icon: '',
+        name: 'destination',
+        path: '/root/destination',
+        posInSet: 1,
+        selected: false,
+        setSize: 2,
+        type: DirentType.Directory,
+      },
+    ],
+  }
+
+  const result = await updateEditingValue(state, 'destination')
+
+  expect(result.editingErrorMessage).toBe('A file or folder **destination** already exists at this location. Please choose a different name.')
 })


### PR DESCRIPTION
## Summary

- validate rename values against visible sibling names while editing and when accepting the rename
- reject an existing sibling destination before invoking the platform rename operation
- preserve current-name and case-only renames by excluding the edited item from collision checks
- add unit and E2E regressions for empty-folder collisions

## Verification

- `npm run build`
- `npm run build:static`
- `npm test` (223 suites passed, 875 tests passed)
- `npm run type-check`
- `npm run lint`
- focused empty-folder collision E2E passed locally before the local browser harness became unavailable; fresh cross-platform CI is the authoritative browser verification

Resolves the manual test report `explorer-rename-folder-collision`.