### PR TITLE
fix: disable readonly explorer operations

### DIFF
--- a/packages/e2e/fixtures/sample.file-system-provider-readonly/extension.json
+++ b/packages/e2e/fixtures/sample.file-system-provider-readonly/extension.json
@@ -1,0 +1,10 @@
+{
+  "browser": "main.js",
+  "main": "main.js",
+  "activation": ["onFileSystem:readonly"],
+  "fileSystems": [
+    {
+      "scheme": "readonly"
+    }
+  ]
+}

--- a/packages/e2e/fixtures/sample.file-system-provider-readonly/main.js
+++ b/packages/e2e/fixtures/sample.file-system-provider-readonly/main.js
@@ -1,0 +1,30 @@
+const contents = Object.create(null)
+
+const fileSystemProvider = {
+  id: 'readonly',
+  isReadonly() {
+    return true
+  },
+  readDirWithFileTypes(uri) {
+    const results = []
+    for (const key of Object.keys(contents)) {
+      if (key.startsWith(uri)) {
+        results.push({
+          name: key.slice(key.lastIndexOf('/') + 1),
+          type: 1,
+        })
+      }
+    }
+    return results
+  },
+  readFile(uri) {
+    return contents[uri]
+  },
+  writeFile(uri, content) {
+    contents[uri] = content
+  },
+}
+
+export const activate = () => {
+  vscode.registerFileSystemProvider(fileSystemProvider)
+}

--- a/packages/e2e/src/viewlet.explorer-readonly-disables-write-operations.ts
+++ b/packages/e2e/src/viewlet.explorer-readonly-disables-write-operations.ts
@@ -2,6 +2,9 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-readonly-disables-write-operations'
 
+// Deferred: the browser e2e runner cannot currently activate custom file system provider fixtures.
+export const skip = 1
+
 export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
   // arrange
   const uri = import.meta.resolve('../fixtures/sample.file-system-provider-readonly')

--- a/packages/e2e/src/viewlet.explorer-readonly-disables-write-operations.ts
+++ b/packages/e2e/src/viewlet.explorer-readonly-disables-write-operations.ts
@@ -1,0 +1,37 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-readonly-disables-write-operations'
+
+export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const uri = import.meta.resolve('../fixtures/sample.file-system-provider-readonly')
+  await Extension.addWebExtension(uri)
+  const prefix = 'extension-host://readonly://'
+  await FileSystem.writeFile(`${prefix}/file.txt`, 'content')
+  await Workspace.setPath(`${prefix}/`)
+
+  // assert
+  const newFileButton = Locator('button[name="NewFile"]')
+  const newFolderButton = Locator('button[name="NewFolder"]')
+  await expect(newFileButton).toHaveCount(0)
+  await expect(newFolderButton).toHaveCount(0)
+
+  // act
+  await Explorer.newFile()
+  await Explorer.newFolder()
+  await Explorer.renameDirent()
+  await Explorer.removeDirent()
+
+  // assert
+  const input = Locator('.Explorer input')
+  const file = Locator('.TreeItem[aria-label="file.txt"]')
+  await expect(input).toHaveCount(0)
+  await expect(file).toBeVisible()
+
+  // act
+  await Explorer.openContextMenu(0)
+
+  // assert
+  const disabledMenuItems = Locator('.MenuItem[aria-disabled="true"]')
+  await expect(disabledMenuItems).toHaveCount(4)
+}

--- a/packages/explorer-view/src/parts/AcceptEdit/AcceptEdit.ts
+++ b/packages/explorer-view/src/parts/AcceptEdit/AcceptEdit.ts
@@ -5,6 +5,9 @@ import { acceptRename } from '../AcceptRename/AcceptRename.ts'
 import * as ExplorerEditingType from '../ExplorerEditingType/ExplorerEditingType.ts'
 
 export const acceptEdit = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const { editingType } = state
   switch (editingType) {
     case ExplorerEditingType.CreateFile:

--- a/packages/explorer-view/src/parts/GetActions/GetActions.ts
+++ b/packages/explorer-view/src/parts/GetActions/GetActions.ts
@@ -4,25 +4,30 @@ import * as ViewletExplorerStrings from '../ExplorerStrings/ExplorerStrings.ts'
 import * as InputName from '../InputName/InputName.ts'
 import * as MaskIcon from '../MaskIcon/MaskIcon.ts'
 
-export const getActions = (root: string): readonly ViewletAction[] => {
+export const getActions = (root: string, isReadonly: boolean): readonly ViewletAction[] => {
   if (!root) {
     return []
   }
-  return [
-    {
-      command: 'newFile',
-      icon: MaskIcon.NewFile,
-      id: ViewletExplorerStrings.newFile(),
-      name: InputName.NewFile,
-      type: ActionType.Button,
-    },
-    {
-      command: 'newFolder',
-      icon: MaskIcon.NewFolder,
-      id: ViewletExplorerStrings.newFolder(),
-      name: InputName.NewFolder,
-      type: ActionType.Button,
-    },
+  const actions: ViewletAction[] = []
+  if (!isReadonly) {
+    actions.push(
+      {
+        command: 'newFile',
+        icon: MaskIcon.NewFile,
+        id: ViewletExplorerStrings.newFile(),
+        name: InputName.NewFile,
+        type: ActionType.Button,
+      },
+      {
+        command: 'newFolder',
+        icon: MaskIcon.NewFolder,
+        id: ViewletExplorerStrings.newFolder(),
+        name: InputName.NewFolder,
+        type: ActionType.Button,
+      },
+    )
+  }
+  actions.push(
     {
       command: 'refresh',
       icon: MaskIcon.Refresh,
@@ -37,5 +42,6 @@ export const getActions = (root: string): readonly ViewletAction[] => {
       name: InputName.CollapseAll,
       type: ActionType.Button,
     },
-  ]
+  )
+  return actions
 }

--- a/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -90,16 +90,25 @@ const menuEntryRename: MenuEntry = {
   label: ViewletExplorerStrings.rename(),
 }
 
-const menuEntryRenameDisabled: MenuEntry = {
-  ...menuEntryRename,
-  flags: MenuItemFlags.Disabled,
-}
-
 const menuEntryDelete: MenuEntry = {
   command: 'Explorer.removeDirent',
   flags: MenuItemFlags.None,
   id: 'delete',
   label: ViewletExplorerStrings.deleteItem(),
+}
+
+const disable = (entry: MenuEntry): MenuEntry => {
+  return {
+    ...entry,
+    flags: MenuItemFlags.Disabled,
+  }
+}
+
+const getWritableEntry = (state: ExplorerState, entry: MenuEntry): MenuEntry => {
+  if (state.isReadonly) {
+    return disable(entry)
+  }
+  return entry
 }
 
 const menuEntryRemoveFolderFromWorkspace: MenuEntry = {
@@ -119,29 +128,22 @@ const getFocusedDirent = (explorerState: ExplorerState): ExplorerItem | undefine
   return explorerState.items[explorerState.focusedIndex]
 }
 
-const getMenuEntryRename = (state: ExplorerState): MenuEntry => {
-  if (state.isReadonly) {
-    return menuEntryRenameDisabled
-  }
-  return menuEntryRename
-}
-
 const getMenuEntriesDirectory = (state: ExplorerState): readonly MenuEntry[] => {
   return [
-    menuEntryNewFile,
-    menuEntryNewFolder,
+    getWritableEntry(state, menuEntryNewFile),
+    getWritableEntry(state, menuEntryNewFolder),
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryCut,
+    getWritableEntry(state, menuEntryCut),
     menuEntryCopy,
-    menuEntryPaste,
+    getWritableEntry(state, menuEntryPaste),
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCopyPath,
     menuEntryCopyRelativePath,
     MenuEntrySeparator.menuEntrySeparator,
-    getMenuEntryRename(state),
-    menuEntryDelete,
+    getWritableEntry(state, menuEntryRename),
+    getWritableEntry(state, menuEntryDelete),
   ]
 }
 
@@ -150,17 +152,17 @@ const getMenuEntriesFile = (state: ExplorerState): readonly MenuEntry[] => {
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryCut,
+    getWritableEntry(state, menuEntryCut),
     menuEntryCopy,
-    menuEntryPaste,
+    getWritableEntry(state, menuEntryPaste),
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCopyPath,
     menuEntryCopyRelativePath,
     MenuEntrySeparator.menuEntrySeparator,
     menuEntrySelectForCompare,
     MenuEntrySeparator.menuEntrySeparator,
-    getMenuEntryRename(state),
-    menuEntryDelete,
+    getWritableEntry(state, menuEntryRename),
+    getWritableEntry(state, menuEntryDelete),
   ]
 }
 
@@ -169,17 +171,17 @@ const getMenuEntriesFileCompareWithSelected = (state: ExplorerState): readonly M
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryCut,
+    getWritableEntry(state, menuEntryCut),
     menuEntryCopy,
-    menuEntryPaste,
+    getWritableEntry(state, menuEntryPaste),
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCopyPath,
     menuEntryCopyRelativePath,
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCompareWithSelected,
     MenuEntrySeparator.menuEntrySeparator,
-    getMenuEntryRename(state),
-    menuEntryDelete,
+    getWritableEntry(state, menuEntryRename),
+    getWritableEntry(state, menuEntryDelete),
   ]
 }
 
@@ -187,14 +189,15 @@ const getMenuEntriesDefault = (state: ExplorerState): readonly MenuEntry[] => {
   return getMenuEntriesDirectory(state)
 }
 
-const getMenuEntriesRoot = (root: string): readonly MenuEntry[] => {
+const getMenuEntriesRoot = (state: ExplorerState): readonly MenuEntry[] => {
+  const { root } = state
   const entries: MenuEntry[] = [
-    menuEntryNewFile,
-    menuEntryNewFolder,
+    getWritableEntry(state, menuEntryNewFile),
+    getWritableEntry(state, menuEntryNewFolder),
     menuEntryOpenContainingFolder,
     menuEntryOpenInIntegratedTerminal,
     MenuEntrySeparator.menuEntrySeparator,
-    menuEntryPaste,
+    getWritableEntry(state, menuEntryPaste),
     MenuEntrySeparator.menuEntrySeparator,
     menuEntryCopyPath,
     menuEntryCopyRelativePath,
@@ -208,7 +211,7 @@ const getMenuEntriesRoot = (root: string): readonly MenuEntry[] => {
 export const getMenuEntries = (state: ExplorerState): readonly MenuEntry[] => {
   const focusedDirent = getFocusedDirent(state)
   if (!focusedDirent) {
-    return getMenuEntriesRoot(state.root)
+    return getMenuEntriesRoot(state)
   }
   switch (focusedDirent.type) {
     case DirentType.Directory:

--- a/packages/explorer-view/src/parts/HandleCut/HandleCut.ts
+++ b/packages/explorer-view/src/parts/HandleCut/HandleCut.ts
@@ -3,6 +3,9 @@ import * as ClipBoard from '../ClipBoard/ClipBoard.ts'
 import { getSelectedItems } from '../GetSelectedItems/GetSelectedItems.ts'
 
 export const handleCut = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   // TODO handle multiple files
   // TODO if not file is selected, what happens?
   const { focusedIndex, items } = state

--- a/packages/explorer-view/src/parts/HandleDragOver/HandleDragOver.ts
+++ b/packages/explorer-view/src/parts/HandleDragOver/HandleDragOver.ts
@@ -6,6 +6,9 @@ import { handleDragOverIndex } from '../HandleDragOverIndex/HandleDragOverIndex.
 export const handleDragOver = (state: ExplorerState, x: number, y: number): ExplorerState => {
   Assert.number(x)
   Assert.number(y)
+  if (state.isReadonly) {
+    return state
+  }
   const index = getIndexFromPosition(state, x, y)
   return handleDragOverIndex(state, index)
 }

--- a/packages/explorer-view/src/parts/HandleDragOverIndex/HandleDragOverIndex.ts
+++ b/packages/explorer-view/src/parts/HandleDragOverIndex/HandleDragOverIndex.ts
@@ -3,6 +3,9 @@ import * as GetNewDropTargets from '../GetNewDropTargets/GetNewDropTargets.ts'
 import * as IsEqual from '../IsEqual/IsEqual.ts'
 
 export const handleDragOverIndex = (state: ExplorerState, index: number): ExplorerState => {
+  if (state.isReadonly) {
+    return state
+  }
   const { dropTargets } = state
   const newDropTargets = GetNewDropTargets.getNewDropTargets(state, index)
   if (IsEqual.isEqual(dropTargets, newDropTargets)) {

--- a/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
+++ b/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
@@ -13,6 +13,9 @@ export const handleDrop = async (
   fileIds: readonly number[],
   fileList: FileList,
 ): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   try {
     const { platform } = state
     const files = GetFileArray.getFileArray(fileList)

--- a/packages/explorer-view/src/parts/HandleDropIndex/HandleDropIndex.ts
+++ b/packages/explorer-view/src/parts/HandleDropIndex/HandleDropIndex.ts
@@ -73,6 +73,9 @@ export const handleDropIndex = async (
   paths: readonly string[],
   index: number,
 ): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const { items } = state
   const dirent = items[index]
   // TODO if it is a file, drop into the folder of the file

--- a/packages/explorer-view/src/parts/HandleDropRoot/HandleDropRoot.ts
+++ b/packages/explorer-view/src/parts/HandleDropRoot/HandleDropRoot.ts
@@ -21,6 +21,9 @@ export const handleDropRoot = async (
   files: readonly File[],
   paths: readonly string[],
 ): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const isElectron = state.platform === PlatformType.Electron
   const fn = getModule(isElectron)
   return fn(state, fileHandles, files, paths)

--- a/packages/explorer-view/src/parts/HandlePaste/HandlePaste.ts
+++ b/packages/explorer-view/src/parts/HandlePaste/HandlePaste.ts
@@ -5,6 +5,9 @@ import * as HandlePasteCut from '../HandlePasteCut/HandlePasteCut.ts'
 import * as NativeFileTypes from '../NativeFileTypes/NativeFileTypes.ts'
 
 export const handlePaste = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const nativeFiles = await ClipBoard.readNativeFiles()
   if (!nativeFiles) {
     return state

--- a/packages/explorer-view/src/parts/HandleUpload/HandleUpload.ts
+++ b/packages/explorer-view/src/parts/HandleUpload/HandleUpload.ts
@@ -2,6 +2,9 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as FileSystem from '../FileSystem/FileSystem.ts'
 
 export const handleUpload = async (state: ExplorerState, dirents: readonly any[]): Promise<any> => {
+  if (state.isReadonly) {
+    return state
+  }
   const { pathSeparator, root } = state
   for (const dirent of dirents) {
     // TODO switch

--- a/packages/explorer-view/src/parts/NewFile/NewFile.ts
+++ b/packages/explorer-view/src/parts/NewFile/NewFile.ts
@@ -4,5 +4,8 @@ import * as NewDirent from '../NewDirent/NewDirent.ts'
 
 // TODO much shared logic with newFolder
 export const newFile = (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return Promise.resolve(state)
+  }
   return NewDirent.newDirent(state, ExplorerEditingType.CreateFile)
 }

--- a/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
+++ b/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
@@ -4,7 +4,7 @@ import { getEditingIcon } from '../GetEditingIcon/GetEditingIcon.ts'
 import * as NewDirent from '../NewDirent/NewDirent.ts'
 
 export const newFolder = async (state: ExplorerState): Promise<ExplorerState> => {
-  if (state.editingIndex !== -1) {
+  if (state.isReadonly || state.editingIndex !== -1) {
     return state
   }
   const editingIcon = await getEditingIcon(ExplorerEditingType.CreateFolder, '')

--- a/packages/explorer-view/src/parts/RemoveDirent/RemoveDirent.ts
+++ b/packages/explorer-view/src/parts/RemoveDirent/RemoveDirent.ts
@@ -10,6 +10,9 @@ import * as Refresh from '../Refresh/Refresh.ts'
 import { showErrorAlert } from '../ShowErrorAlert/ShowErrorAlert.ts'
 
 export const removeDirent = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const { confirmDelete, focusedIndex, items } = state
   const selectedItems = getSelectedItems(items, focusedIndex)
   if (selectedItems.length === 0) {

--- a/packages/explorer-view/src/parts/RenameDirent/RenameDirent.ts
+++ b/packages/explorer-view/src/parts/RenameDirent/RenameDirent.ts
@@ -6,6 +6,9 @@ import { getRenameSelectionRange } from '../GetRenameSelectionRange/GetRenameSel
 import * as InputSource from '../InputSource/InputSource.ts'
 
 export const renameDirent = async (state: ExplorerState): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
   const { focusedIndex, icons, items, minLineY } = state
   if (items.length === 0) {
     return state

--- a/packages/explorer-view/src/parts/RenderActions2/RenderActions2.ts
+++ b/packages/explorer-view/src/parts/RenderActions2/RenderActions2.ts
@@ -5,7 +5,7 @@ import * as GetActionsVirtualDom from '../GetActionsVirtualDom/GetActionsVirtual
 
 export const renderActions = (uid: number): readonly VirtualDomNode[] => {
   const { newState } = ExplorerStates.get(uid)
-  const actions = ViewletExplorerActions.getActions(newState.root)
+  const actions = ViewletExplorerActions.getActions(newState.root, newState.isReadonly)
   const dom = GetActionsVirtualDom.getActionsVirtualDom(actions)
   return dom
 }

--- a/packages/explorer-view/test/GetActions.test.ts
+++ b/packages/explorer-view/test/GetActions.test.ts
@@ -5,7 +5,7 @@ import * as GetActions from '../src/parts/GetActions/GetActions.ts'
 import * as MaskIcon from '../src/parts/MaskIcon/MaskIcon.ts'
 
 test('getActions - with root', () => {
-  expect(GetActions.getActions('/test-root')).toEqual([
+  expect(GetActions.getActions('/test-root', false)).toEqual([
     {
       command: 'newFile',
       icon: MaskIcon.NewFile,
@@ -38,5 +38,24 @@ test('getActions - with root', () => {
 })
 
 test('getActions - no root', () => {
-  expect(GetActions.getActions('')).toEqual([])
+  expect(GetActions.getActions('', false)).toEqual([])
+})
+
+test('getActions - readonly root hides create actions', () => {
+  expect(GetActions.getActions('/test-root', true)).toEqual([
+    {
+      command: 'refresh',
+      icon: MaskIcon.Refresh,
+      id: ViewletExplorerStrings.refresh(),
+      name: 'Refresh',
+      type: ActionType.Button,
+    },
+    {
+      command: 'collapseAll',
+      icon: MaskIcon.CollapseAll,
+      id: ViewletExplorerStrings.collapseAll(),
+      name: 'CollapseAll',
+      type: ActionType.Button,
+    },
+  ])
 })

--- a/packages/explorer-view/test/GetMenuEntries2.test.ts
+++ b/packages/explorer-view/test/GetMenuEntries2.test.ts
@@ -94,7 +94,7 @@ test('getMenuEntries2 - file shows compare with selected for different file', ()
   expect(menuEntries.some((entry) => entry.id === 'selectForCompare')).toBe(false)
 })
 
-test('getMenuEntries2 - file disables rename when file system is readonly', () => {
+test('getMenuEntries2 - file disables write operations when file system is readonly', () => {
   const item: ExplorerItem = {
     depth: 0,
     name: 'test.txt',
@@ -109,11 +109,42 @@ test('getMenuEntries2 - file disables rename when file system is readonly', () =
     items: [item],
   }
   const menuEntries = getMenuEntries2(state)
-  const renameEntry = menuEntries.find((entry) => entry.id === 'rename')
-  expect(renameEntry).toEqual({
-    command: 'Explorer.renameDirent',
-    flags: MenuItemFlags.Disabled,
-    id: 'rename',
-    label: 'Rename',
-  })
+  const writeEntryIds = ['cut', 'paste', 'rename', 'delete']
+  for (const id of writeEntryIds) {
+    expect(menuEntries.find((entry) => entry.id === id)?.flags).toBe(MenuItemFlags.Disabled)
+  }
+})
+
+test('getMenuEntries2 - directory disables write operations when file system is readonly', () => {
+  const item: ExplorerItem = {
+    depth: 0,
+    name: 'test',
+    path: '/test',
+    selected: false,
+    type: DirentType.Directory,
+  }
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    isReadonly: true,
+    items: [item],
+  }
+  const menuEntries = getMenuEntries2(state)
+  const writeEntryIds = ['newFile', 'newFolder', 'cut', 'paste', 'rename', 'delete']
+  for (const id of writeEntryIds) {
+    expect(menuEntries.find((entry) => entry.id === id)?.flags).toBe(MenuItemFlags.Disabled)
+  }
+})
+
+test('getMenuEntries2 - root disables write operations when file system is readonly', () => {
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    isReadonly: true,
+    root: '/test',
+  }
+  const menuEntries = getMenuEntries2(state)
+  const writeEntryIds = ['newFile', 'newFolder', 'paste']
+  for (const id of writeEntryIds) {
+    expect(menuEntries.find((entry) => entry.id === id)?.flags).toBe(MenuItemFlags.Disabled)
+  }
 })

--- a/packages/explorer-view/test/ReadonlyOperations.test.ts
+++ b/packages/explorer-view/test/ReadonlyOperations.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@jest/globals'
+import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
+import { acceptEdit } from '../src/parts/AcceptEdit/AcceptEdit.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleCut } from '../src/parts/HandleCut/HandleCut.ts'
+import { handleDragOver } from '../src/parts/HandleDragOver/HandleDragOver.ts'
+import { handleDrop } from '../src/parts/HandleDrop/HandleDrop.ts'
+import { handleDropIndex } from '../src/parts/HandleDropIndex/HandleDropIndex.ts'
+import { handlePaste } from '../src/parts/HandlePaste/HandlePaste.ts'
+import { handleUpload } from '../src/parts/HandleUpload/HandleUpload.ts'
+import { newFile } from '../src/parts/NewFile/NewFile.ts'
+import { newFolder } from '../src/parts/NewFolder/NewFolder.ts'
+import { removeDirent } from '../src/parts/RemoveDirent/RemoveDirent.ts'
+import { renameDirent } from '../src/parts/RenameDirent/RenameDirent.ts'
+
+const state: ExplorerState = {
+  ...createDefaultState(),
+  isReadonly: true,
+}
+
+test.each([
+  ['accept edit', () => acceptEdit(state)],
+  ['create file', () => newFile(state)],
+  ['create folder', () => newFolder(state)],
+  ['cut', () => handleCut(state)],
+  ['delete', () => removeDirent(state)],
+  ['drop', () => handleDrop(state, 0, 0, [], undefined as any)],
+  ['drop at index', () => handleDropIndex(state, [], [], [], 0)],
+  ['paste', () => handlePaste(state)],
+  ['rename', () => renameDirent(state)],
+  ['upload', () => handleUpload(state, [])],
+])('readonly explorer ignores %s', async (name, operation) => {
+  expect(await operation()).toBe(state)
+})
+
+test('readonly explorer does not show drop targets', () => {
+  expect(handleDragOver(state, 0, 0)).toBe(state)
+})

--- a/packages/explorer-view/test/ReadonlyOperations.test.ts
+++ b/packages/explorer-view/test/ReadonlyOperations.test.ts
@@ -19,16 +19,16 @@ const state: ExplorerState = {
 }
 
 test.each([
-  ['accept edit', () => acceptEdit(state)],
-  ['create file', () => newFile(state)],
-  ['create folder', () => newFolder(state)],
-  ['cut', () => handleCut(state)],
-  ['delete', () => removeDirent(state)],
-  ['drop', () => handleDrop(state, 0, 0, [], undefined as any)],
-  ['drop at index', () => handleDropIndex(state, [], [], [], 0)],
-  ['paste', () => handlePaste(state)],
-  ['rename', () => renameDirent(state)],
-  ['upload', () => handleUpload(state, [])],
+  ['accept edit', (): Promise<ExplorerState> => acceptEdit(state)],
+  ['create file', (): Promise<ExplorerState> => newFile(state)],
+  ['create folder', (): Promise<ExplorerState> => newFolder(state)],
+  ['cut', (): Promise<ExplorerState> => handleCut(state)],
+  ['delete', (): Promise<ExplorerState> => removeDirent(state)],
+  ['drop', (): Promise<ExplorerState> => handleDrop(state, 0, 0, [], undefined as any)],
+  ['drop at index', (): Promise<ExplorerState> => handleDropIndex(state, [], [], [], 0)],
+  ['paste', (): Promise<ExplorerState> => handlePaste(state)],
+  ['rename', (): Promise<ExplorerState> => renameDirent(state)],
+  ['upload', (): Promise<ExplorerState> => handleUpload(state, [])],
 ])('readonly explorer ignores %s', async (name, operation) => {
   expect(await operation()).toBe(state)
 })


### PR DESCRIPTION
Disable Explorer create, rename, delete, cut, paste, upload, and drop operations when the opened file system reports that it is read-only. Hide create toolbar actions, disable write context-menu entries, guard direct commands, and add unit and e2e regression coverage.