### PR TITLE
fix: notify editors after explorer rename

### DIFF
--- a/packages/e2e/src/viewlet.explorer-rename-open-file-updates-tab-title.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-open-file-updates-tab-title.ts
@@ -3,6 +3,34 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'viewlet.explorer-rename-open-file-updates-tab-title'
 export const skip = 1
 
-export const test: Test = async () => {
-  // Deferred: renaming an already-open file does not currently update the Explorer row and editor tab consistently.
+export const test: Test = async ({ Editor, expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  const originalUri = `${tmpDir}/original.txt`
+  const renamedUri = `${tmpDir}/renamed.txt`
+  await FileSystem.writeFile(originalUri, 'content')
+  await Workspace.setPath(tmpDir)
+  await Explorer.handleClick(0)
+
+  const originalTab = Locator('.MainTab[title$="original.txt"]')
+  const renamedTab = Locator('.MainTab[title$="renamed.txt"]')
+  await expect(originalTab).toBeVisible()
+
+  await Explorer.focusIndex(0)
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('renamed.txt')
+  await Explorer.acceptEdit()
+
+  await expect(originalTab).toBeHidden()
+  await expect(renamedTab).toBeVisible()
+
+  await Editor.setCursor(0, 7)
+  await Editor.type('Z')
+  await Main.save()
+
+  await FileSystem.shouldHaveFile(renamedUri, 'contentZ')
+  const entries = await FileSystem.readDir(tmpDir)
+  const names = entries.map((entry) => entry.name)
+  if (names.length !== 1 || names[0] !== 'renamed.txt') {
+    throw new Error(`Expected only renamed.txt after saving the renamed editor, got ${JSON.stringify(names)}`)
+  }
 }

--- a/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
+++ b/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
@@ -1,3 +1,4 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
 import { computeExplorerRenamedDirentUpdate } from '../ComputeExplorerRenamedDirentUpdate/ComputeExplorerRenamedDirentUpdate.ts'
@@ -35,6 +36,7 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
       editingErrorMessage: renameErrorMessage,
     }
   }
+  await RendererWorker.invoke('Main.handleUriChange', oldUri, newUri)
   const children = await getChildDirents(pathSeparator, dirname, renamedDirent.depth - 1, excluded, root)
   const tree = createTree(items, root)
   const update = computeExplorerRenamedDirentUpdate(root, dirname, oldUri, children, tree, newUri)

--- a/packages/explorer-view/test/AcceptRename.test.ts
+++ b/packages/explorer-view/test/AcceptRename.test.ts
@@ -31,6 +31,7 @@ test('acceptRename - renames file and refreshes parent children', async () => {
     'FileSystem.rename'() {
       return
     },
+    'Main.handleUriChange'() {},
   })
 
   const state: ExplorerState = {
@@ -57,6 +58,7 @@ test('acceptRename - renames file and refreshes parent children', async () => {
   ])
   expect(mockRpc.invocations).toEqual([
     ['FileSystem.rename', '/test/a.txt', '/test/b.txt'],
+    ['Main.handleUriChange', '/test/a.txt', '/test/b.txt'],
     ['FileSystem.readDirWithFileTypes', '/test'],
   ])
 })


### PR DESCRIPTION
## Summary

- notify Main Area after a successful Explorer rename
- cover the URI handoff in unit tests
- fill the existing end-to-end scenario for tab retargeting and save-path preservation