### PR TITLE
test: verify explorer mouse wheel scrolling

### DIFF
--- a/packages/e2e/src/viewlet.explorer-scroll.ts
+++ b/packages/e2e/src/viewlet.explorer-scroll.ts
@@ -11,8 +11,10 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   }
   await Workspace.setPath(tmpDir)
   const file00 = Locator('.TreeItem', { hasText: 'file-00.txt' })
+  const file23 = Locator('.TreeItem', { hasText: 'file-23.txt' })
   const file50 = Locator('.TreeItem', { hasText: 'file-50.txt' })
   const file99 = Locator('.TreeItem', { hasText: 'file-99.txt' })
+  const list = Locator('.ListItems')
 
   // act
   await Explorer.focusFirst()
@@ -20,6 +22,27 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   // assert
   await expect(file00).toBeVisible()
   await expect(file00).toHaveId('TreeItemActive')
+
+  // act
+  await list.dispatchEvent('wheel', {
+    bubbles: true,
+    deltaMode: 0,
+    deltaY: 500,
+  } as unknown as string)
+
+  // assert
+  await expect(file00).toBeHidden()
+  await expect(file23).toBeVisible()
+
+  // act
+  await list.dispatchEvent('wheel', {
+    bubbles: true,
+    deltaMode: 0,
+    deltaY: -500,
+  } as unknown as string)
+
+  // assert
+  await expect(file00).toBeVisible()
 
   // act
   await Explorer.focusIndex(50)


### PR DESCRIPTION
## Summary
- add regression coverage for pixel-based mouse-wheel scrolling in the Explorer tree
- verify scrolling down changes the visible range and scrolling back up restores it

## Context
The manual report could not be reproduced when the wheel event was targeted at the Explorer list. The reporting automation moved the pointer into Explorer but emitted the subsequent wheel input at coordinates (0,0), targeting the title bar instead of the tree.

The current Explorer wheel handler scrolls correctly when it receives the event. This E2E exercises that path directly on .ListItems so a real regression will be caught.

## Validation
- focused Chromium E2E: viewlet.explorer-scroll
- focused Firefox E2E: viewlet.explorer-scroll
- npm test --workspace=packages/explorer-view (891 passing)
- npm run type-check
- npm run lint
- npm run build
- npm run build:static
- git diff --check