### PR TITLE
feature: add explorer keyboard navigation e2e tests

### DIFF
--- a/packages/e2e/src/viewlet.explorer-arrow-right-expands-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-expands-folder.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-arrow-right-expands-folder'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+
+  // act
+  await Command.execute('Explorer.handleArrowRight')
+
+  // assert
+  const folder = Locator('.TreeItem[aria-label="folder"]')
+  const file = Locator('.TreeItem[aria-label="file.txt"]')
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(folder).toHaveId('TreeItemActive')
+  await expect(file).toBeVisible()
+}

--- a/packages/e2e/src/viewlet.explorer-arrow-right-file-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-file-no-op.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-arrow-right-file-no-op'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+
+  // act
+  await Command.execute('Explorer.handleArrowRight')
+
+  // assert
+  const file = Locator('.TreeItem[aria-label="file.txt"]')
+  const editorTab = Locator('.MainTab[title$="file.txt"]')
+  await expect(file).toHaveId('TreeItemActive')
+  await expect(editorTab).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-arrow-right-focuses-first-child.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-focuses-first-child.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-arrow-right-focuses-first-child'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+  await Explorer.clickCurrent()
+
+  // act
+  await Command.execute('Explorer.handleArrowRight')
+
+  // assert
+  const folder = Locator('.TreeItem[aria-label="folder"]')
+  const file = Locator('.TreeItem[aria-label="file.txt"]')
+  await expect(folder).toHaveAttribute('aria-expanded', 'true')
+  await expect(file).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-focus-next-at-end.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-next-at-end.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-focus-next-at-end'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(1)
+
+  // act
+  await Explorer.focusNext()
+
+  // assert
+  const lastFile = Locator('.TreeItem[aria-label="b.txt"]')
+  await expect(lastFile).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-focus-previous-at-start.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-at-start.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-focus-previous-at-start'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+
+  // act
+  await Command.execute('Explorer.focusPrevious')
+
+  // assert
+  const firstFile = Locator('.TreeItem[aria-label="a.txt"]')
+  await expect(firstFile).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-focus-previous-without-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-without-focus.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-focus-previous-without-focus'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
+  await Workspace.setPath(tmpDir)
+
+  // act
+  await Command.execute('Explorer.focusPrevious')
+
+  // assert
+  const lastFile = Locator('.TreeItem[aria-label="b.txt"]')
+  await expect(lastFile).toHaveId('TreeItemActive')
+}


### PR DESCRIPTION
Adds end-to-end coverage for Right Arrow folder navigation and file no-op behavior, plus focus navigation boundaries in the Explorer.