### PR TITLE
fix: decouple explorer rename from main area

### DIFF
--- a/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
+++ b/packages/explorer-view/src/parts/AcceptRename/AcceptRename.ts
@@ -1,4 +1,3 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
 import { computeExplorerRenamedDirentUpdate } from '../ComputeExplorerRenamedDirentUpdate/ComputeExplorerRenamedDirentUpdate.ts'
@@ -36,7 +35,6 @@ export const acceptRename = async (state: ExplorerState): Promise<ExplorerState>
       editingErrorMessage: renameErrorMessage,
     }
   }
-  await RendererWorker.invoke('Main.handleUriChange', oldUri, newUri)
   const children = await getChildDirents(pathSeparator, dirname, renamedDirent.depth - 1, excluded, root)
   const tree = createTree(items, root)
   const update = computeExplorerRenamedDirentUpdate(root, dirname, oldUri, children, tree, newUri)

--- a/packages/explorer-view/test/AcceptRename.test.ts
+++ b/packages/explorer-view/test/AcceptRename.test.ts
@@ -31,7 +31,6 @@ test('acceptRename - renames file and refreshes parent children', async () => {
     'FileSystem.rename'() {
       return
     },
-    'Main.handleUriChange'() {},
   })
 
   const state: ExplorerState = {
@@ -58,7 +57,6 @@ test('acceptRename - renames file and refreshes parent children', async () => {
   ])
   expect(mockRpc.invocations).toEqual([
     ['FileSystem.rename', '/test/a.txt', '/test/b.txt'],
-    ['Main.handleUriChange', '/test/a.txt', '/test/b.txt'],
     ['FileSystem.readDirWithFileTypes', '/test'],
   ])
 })


### PR DESCRIPTION
## Summary

- remove Explorer's direct Main Area rename notification
- rely on the renderer filesystem's structured Layout workspace-change event
- keep Explorer independent of Main Area implementation details