### PR TITLE
fix: open explorer files permanently on double click

### DIFF
--- a/packages/e2e/src/viewlet.explorer-double-click-file-opens-permanently.ts
+++ b/packages/e2e/src/viewlet.explorer-double-click-file-opens-permanently.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-double-click-file-opens-permanently'
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/test.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+
+  await Command.execute('Explorer.handleDoubleClick', 20, 10)
+
+  const editorTab = Locator('.MainTab:not(.MainTabPreview)[title$="test.txt"]')
+  await expect(editorTab).toBeVisible()
+}

--- a/packages/explorer-view/src/parts/HandleDoubleClick/HandleDoubleClick.ts
+++ b/packages/explorer-view/src/parts/HandleDoubleClick/HandleDoubleClick.ts
@@ -1,11 +1,19 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as DirentType from '../DirentType/DirentType.ts'
 import { getIndexFromPosition } from '../GetIndexFromPosition/GetIndexFromPosition.ts'
 import { newFile } from '../NewFile/NewFile.ts'
+import { normalizeDirentType } from '../NormalizeDirentType/NormalizeDirentType.ts'
+import * as OpenUri from '../OpenUri/OpenUri.ts'
 
 export const handleDoubleClick = async (state: ExplorerState, eventX: number, eventY: number): Promise<ExplorerState> => {
   const index = getIndexFromPosition(state, eventX, eventY)
-  if (index !== -1) {
-    return state
+  if (index === -1) {
+    return newFile(state)
   }
-  return newFile(state)
+  const item = state.items[index]
+  const type = normalizeDirentType(item.type)
+  if (type === DirentType.File || type === DirentType.SymLinkFile) {
+    await OpenUri.openUri(item.path, true)
+  }
+  return state
 }

--- a/packages/explorer-view/test/HandleDoubleClick.test.ts
+++ b/packages/explorer-view/test/HandleDoubleClick.test.ts
@@ -98,6 +98,29 @@ test('handleDoubleClick - double click on item returns same state', async () => 
   expect(result).toBe(state)
 })
 
+test.each([
+  ['file', DirentType.File],
+  ['symlinked file', DirentType.SymLinkFile],
+])('handleDoubleClick - double click on %s opens it permanently', async (_name, type) => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri'() {},
+  })
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    itemHeight: 20,
+    items: [{ depth: 0, name: 'test.txt', path: '/test.txt', selected: false, type }],
+    maxLineY: 1,
+    minLineY: 0,
+    y: 0,
+  }
+
+  const result = await handleDoubleClick(state, 0, 10)
+
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['Main.openUri', '/test.txt', true]])
+})
+
 test('handleDoubleClick - double click on item with multiple items returns same state', async () => {
   const state: ExplorerState = {
     ...createDefaultState(),


### PR DESCRIPTION
## Summary
- open files and symlinked files permanently when they are double-clicked in Explorer
- keep the existing empty-area and directory double-click behavior unchanged
- add unit and end-to-end coverage for the permanent-tab behavior

## Validation
- `npm test` (891 passed, 45 skipped)
- `npm run type-check`
- `npm run lint`
- `npm run measure`
- focused headless e2e: `viewlet.explorer-double-click-file-opens-permanently`