### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...regex.default,
   ...tsconfig.default,
   {
@@ -41,6 +42,19 @@ export default [
     files: ['**/*.test.ts'],
     rules: {
       '@typescript-eslint/unbound-method': 'off',
+      'virtual-dom/no-object-attribute-values': 'off',
+      'virtual-dom/no-raw-text-children': 'off',
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
+    },
+  },
+  {
+    files: [
+      'packages/explorer-view/src/parts/{AcceptEdit,CompareWithSelected,CopyPath,CopyRelativePath,Create,Focus,FocusParentFolder,GetFocusedFile,GetLoadErrorMessage,GetMenuEntries,HandleClickAt,HandleClickCurrent,HandleClickCurrentButKeepFocus,HandleClickDirectory,HandleContextMenuKeyboard,HandleCut,HandleDoubleClick,HandleDragOver,HandleDragOverIndex,HandleDrop,HandleDropIndex,HandleDropRoot,HandleDropRootDefault,HandleDropRootElectron,HandleFocus,HandlePaste,HandleResize,HandleUpload,HandleWheel,NewFile,NewFolder,RemoveDirent,RenameDirent,SetDeltaY}/**/*.ts',
+    ],
+    rules: {
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
   ...actions.default,

--- a/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
@@ -20,7 +20,6 @@ export const getExplorerItemVirtualDom = (item: VisibleExplorerItem): readonly V
   const chevronDom = GetChevronVirtualDom.getChevronVirtualDom(chevron)
   return [
     {
-      ariaDescription: '',
       ariaExpanded,
       ariaLabel: name,
       ariaLevel: depth,

--- a/packages/explorer-view/src/parts/GetExplorerWelcomeVirtualDom/GetExplorerWelcomeVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetExplorerWelcomeVirtualDom/GetExplorerWelcomeVirtualDom.ts
@@ -5,6 +5,7 @@ import { dropTargetFull } from '../DropTargetFull/DropTargetFull.ts'
 import * as ExplorerStrings from '../ExplorerStrings/ExplorerStrings.ts'
 import * as InputName from '../InputName/InputName.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
@@ -22,7 +23,7 @@ export const getExplorerWelcomeVirtualDom = (isWide: boolean, dropTargets: reado
       onDragLeave: DomEventListenerFunctions.HandleDragLeave,
       onDragOver: DomEventListenerFunctions.HandleDragOver,
       onDrop: DomEventListenerFunctions.HandleDrop,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     {

--- a/packages/explorer-view/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetIconVirtualDom/GetIconVirtualDom.ts
@@ -1,11 +1,12 @@
 import type { VirtualDomNode } from '../VirtualDomNode/VirtualDomNode.ts'
 import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
+import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 export const getIconVirtualDom = (icon: string, type = VirtualDomElements.Div): VirtualDomNode => {
   return {
     childCount: 0,
-    className: `MaskIcon MaskIcon${icon}`,
+    className: MergeClassNames.mergeClassNames('MaskIcon', `MaskIcon${icon}`),
     role: AriaRoles.None,
     type,
   }

--- a/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
@@ -7,6 +7,7 @@ import { dropTargetFull } from '../DropTargetFull/DropTargetFull.ts'
 import * as ExplorerStrings from '../ExplorerStrings/ExplorerStrings.ts'
 import * as GetExplorerItemVirtualDom from '../GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
 const getActiveDescendant = (focusedIndex: number): string | undefined => {
@@ -48,7 +49,7 @@ export const getListItemsVirtualDom = (
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
       onWheel: DomEventListenerFunctions.HandleWheel,
       role: AriaRoles.Tree,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
       // onKeyDown: DomEventListenerFunctions.HandleListKeyDown,
     },

--- a/packages/explorer-view/src/parts/TabIndex/TabIndex.ts
+++ b/packages/explorer-view/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0


### PR DESCRIPTION
Enable the shared recommended virtual DOM ESLint preset.

Fix production renderer findings by removing an empty ARIA attribute, using the existing class-name merger, and replacing raw focus indices with a named constant. Add narrow exceptions for explorer reducer state and expected tree/DOM test fixtures that are not virtual DOM attributes.

Validation:
- `npm run lint`
- `npm run build`
- `npm run type-check`
- `npm test`
- `npm run measure`