### PR TITLE
feature: add more explorer race e2e tests

### DIFF
--- a/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-accept-rename-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/a.txt`, 'a')
+  await FileSystem.writeFile(`${tmpDir}/b.txt`, 'b')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focusIndex', 0)
+  await Command.execute('Explorer.renameDirent')
+  await Command.execute('Explorer.updateEditingValue', 'renamed.txt')
+
+  // act: acceptEdit renames the file while refresh concurrently reads the old directory state
+  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.refresh')])
+
+  // assert: the accepted name is present on disk and represented once in the tree
+  await FileSystem.shouldHaveFile(`${tmpDir}/renamed.txt`, 'a')
+  const renamed = Locator('.TreeItem[aria-label="renamed.txt"]')
+  const b = Locator('.TreeItem[aria-label="b.txt"]')
+  const inputs = Locator('.Explorer input')
+  await expect(renamed).toHaveCount(1)
+  await expect(renamed).toBeVisible()
+  await expect(b).toBeVisible()
+  await expect(inputs).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  await expect(treeItems).toHaveCount(2)
+}

--- a/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
@@ -1,0 +1,32 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-arrow-left-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, 'child')
+  await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.handleClick', 0)
+  await Command.execute('Explorer.focusIndex', 1)
+
+  // act: handleArrowLeft moves focus to the parent while refresh concurrently rebuilds the tree
+  await Promise.all([Command.execute('Explorer.handleArrowLeft'), Command.execute('Explorer.refresh')])
+
+  // assert: the tree has no stale or duplicate rows
+  const folder = Locator('.TreeItem[aria-label="folder"]')
+  const rootFile = Locator('.TreeItem[aria-label="root.txt"]')
+  const children = Locator('.TreeItem[aria-label="child.txt"]')
+  const duplicateChild = children.nth(1)
+  await expect(folder).toBeVisible()
+  await expect(rootFile).toBeVisible()
+  await expect(duplicateChild).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  const extraTreeItem = treeItems.nth(3)
+  await expect(extraTreeItem).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
@@ -1,0 +1,31 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-collapse-all-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, 'child')
+  await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.expandRecursively')
+
+  // act: collapseAll removes expanded children while refresh concurrently rebuilds the tree
+  await Promise.all([Command.execute('Explorer.collapseAll'), Command.execute('Explorer.refresh')])
+
+  // assert: top-level items remain stable and no child is duplicated
+  const folder = Locator('.TreeItem[aria-label="folder"]')
+  const rootFile = Locator('.TreeItem[aria-label="root.txt"]')
+  const children = Locator('.TreeItem[aria-label="child.txt"]')
+  const duplicateChild = children.nth(1)
+  await expect(folder).toBeVisible()
+  await expect(rootFile).toBeVisible()
+  await expect(duplicateChild).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  const extraTreeItem = treeItems.nth(3)
+  await expect(extraTreeItem).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
@@ -1,0 +1,27 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-copy-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  await ClipBoard.enableMemoryClipBoard()
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focusIndex', 0)
+
+  // act: handleCopy captures the focused item while refresh concurrently replaces that item
+  await Promise.all([Command.execute('Explorer.handleCopy'), Command.execute('Explorer.refresh')])
+
+  // assert: both files remain visible exactly once
+  const file1 = Locator('.TreeItem[aria-label="file1.txt"]')
+  const file2 = Locator('.TreeItem[aria-label="file2.txt"]')
+  await expect(file1).toBeVisible()
+  await expect(file2).toBeVisible()
+
+  const treeItems = Locator('.TreeItem')
+  await expect(treeItems).toHaveCount(2)
+}

--- a/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
@@ -1,0 +1,34 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-expand-all-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/a`)
+  await FileSystem.writeFile(`${tmpDir}/a/a.txt`, 'a')
+  await FileSystem.mkdir(`${tmpDir}/b`)
+  await FileSystem.writeFile(`${tmpDir}/b/b.txt`, 'b')
+  await Workspace.setPath(tmpDir)
+
+  // act: expandAll reads both folders while refresh concurrently replaces their rows
+  await Promise.all([Command.execute('Explorer.expandAll'), Command.execute('Explorer.refresh')])
+
+  // assert: root folders remain visible and neither child is duplicated
+  const a = Locator('.TreeItem[aria-label="a"]')
+  const b = Locator('.TreeItem[aria-label="b"]')
+  const aChildren = Locator('.TreeItem[aria-label="a.txt"]')
+  const bChildren = Locator('.TreeItem[aria-label="b.txt"]')
+  const duplicateAChild = aChildren.nth(1)
+  const duplicateBChild = bChildren.nth(1)
+  await expect(a).toBeVisible()
+  await expect(b).toBeVisible()
+  await expect(duplicateAChild).toBeHidden()
+  await expect(duplicateBChild).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  const extraTreeItem = treeItems.nth(4)
+  await expect(extraTreeItem).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-focus-previous-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
+  await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focusIndex', 2)
+
+  // act: focusPrevious changes the active row while refresh concurrently replaces all rows
+  await Promise.all([Command.execute('Explorer.focusPrevious'), Command.execute('Explorer.refresh')])
+
+  // assert: all files remain visible exactly once
+  const file1 = Locator('.TreeItem[aria-label="file1.txt"]')
+  const file2 = Locator('.TreeItem[aria-label="file2.txt"]')
+  const file3 = Locator('.TreeItem[aria-label="file3.txt"]')
+  await expect(file1).toBeVisible()
+  await expect(file2).toBeVisible()
+  await expect(file3).toBeVisible()
+
+  const treeItems = Locator('.TreeItem')
+  await expect(treeItems).toHaveCount(3)
+}

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-new-folder-cancel-edit'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
+  await Workspace.setPath(tmpDir)
+
+  // act: newFolder inserts an editing row while cancelEdit concurrently tries to remove it
+  await Promise.all([Command.execute('Explorer.newFolder'), Command.execute('Explorer.cancelEdit')])
+
+  // assert: existing rows remain stable and at most one editing row survives
+  const file1 = Locator('.TreeItem[aria-label="file1.txt"]')
+  const file2 = Locator('.TreeItem[aria-label="file2.txt"]')
+  const inputs = Locator('.Explorer input')
+  const duplicateInput = inputs.nth(1)
+  await expect(file1).toBeVisible()
+  await expect(file2).toBeVisible()
+  await expect(duplicateInput).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  const extraTreeItem = treeItems.nth(3)
+  await expect(extraTreeItem).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-new-folder-twice'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
+  await Workspace.setPath(tmpDir)
+
+  // act: two newFolder commands concurrently try to insert an editing row
+  await Promise.all([Command.execute('Explorer.newFolder'), Command.execute('Explorer.newFolder')])
+
+  // assert: the editing guard permits only one row and one input
+  const treeItems = Locator('.TreeItem')
+  const inputs = Locator('.Explorer input')
+  await expect(treeItems).toHaveCount(3)
+  await expect(inputs).toHaveCount(1)
+}

--- a/packages/e2e/src/viewlet.explorer-race-paste-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-paste-twice.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-paste-twice'
+
+export const skip = 1
+
+export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  await ClipBoard.enableMemoryClipBoard()
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/a`)
+  await FileSystem.writeFile(`${tmpDir}/a/file.txt`, 'content')
+  await FileSystem.mkdir(`${tmpDir}/b`)
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.expandRecursively')
+  await Command.execute('Explorer.focusIndex', 1)
+  await Command.execute('Explorer.handleCopy')
+  await Command.execute('Explorer.focusIndex', 2)
+
+  // act: two paste commands concurrently copy the same source into the same target
+  await Promise.all([Command.execute('Explorer.handlePaste'), Command.execute('Explorer.handlePaste')])
+
+  // assert: source and target remain stable without duplicate tree rows for one URI
+  const a = Locator('.TreeItem[aria-label="a"]')
+  const b = Locator('.TreeItem[aria-label="b"]')
+  const sourceFiles = Locator('.TreeItem[aria-label="file.txt"]')
+  const duplicateSource = sourceFiles.nth(2)
+  await expect(a).toBeVisible()
+  await expect(b).toBeVisible()
+  await expect(duplicateSource).toBeHidden()
+
+  const treeItems = Locator('.TreeItem')
+  const extraTreeItem = treeItems.nth(5)
+  await expect(extraTreeItem).toBeHidden()
+}

--- a/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-race-select-up-refresh'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
+  await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focusIndex', 2)
+
+  // act: selectUp extends selection while refresh concurrently replaces the selected rows
+  await Promise.all([Command.execute('Explorer.selectUp'), Command.execute('Explorer.refresh')])
+
+  // assert: all files remain visible exactly once
+  const file1 = Locator('.TreeItem[aria-label="file1.txt"]')
+  const file2 = Locator('.TreeItem[aria-label="file2.txt"]')
+  const file3 = Locator('.TreeItem[aria-label="file3.txt"]')
+  await expect(file1).toBeVisible()
+  await expect(file2).toBeVisible()
+  await expect(file3).toBeVisible()
+
+  const treeItems = Locator('.TreeItem')
+  await expect(treeItems).toHaveCount(3)
+}


### PR DESCRIPTION
Adds ten focused explorer e2e probes for distinct concurrent command races, following the existing skipped regression-test pattern.