### PR TITLE
ci: allow Windows Firefox suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless
+        run: npm run e2e:firefox:headless -- --timeout=900000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure


### PR DESCRIPTION
Follow-up to #1758.

The Windows Firefox e2e suite now takes slightly more than the default 10-minute test harness timeout after the dependency update. Two PR runs and the post-merge CI run timed out at exactly 600000ms while waiting for `.TestResults`; #1761 proved the suite completes successfully with a 900000ms allowance.

This mirrors that tested timeout in the main CI workflow.