### PR TITLE
ci: allow main Windows Firefox suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless
+        run: npm run e2e:firefox:headless -- --timeout=900000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure


### PR DESCRIPTION
## Summary
- pass the validated 900-second reuse-page timeout to the main-branch Firefox CI step
- mirror the PR workflow fix merged in #1761

## Root cause
Windows Firefox repeatedly needs more than the test runner's 600-second default. The merged PR validation passed in 619 seconds, while the first post-merge main run still used the old CI invocation and failed at exactly 600 seconds.

Evidence:
- PR validation: https://github.com/lvce-editor/explorer-view/actions/runs/29692856008
- post-merge main timeout: https://github.com/lvce-editor/explorer-view/actions/runs/29694334236
- 20 instrumented Windows suites completed in 387-753 seconds with a 900-second budget: https://github.com/lvce-editor/explorer-view/actions/runs/29692773318


## Validation
- PR workflow passed on Ubuntu, macOS, and Windows: https://github.com/lvce-editor/explorer-view/actions/runs/29695439647
- post-merge main CI and deploy passed: https://github.com/lvce-editor/explorer-view/actions/runs/29695885216
