### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^16.5.0",
+        "@lvce-editor/eslint-config": "^17.0.3",
         "@lvce-editor/eslint-plugin-github-actions": "^16.5.0",
         "@lvce-editor/eslint-plugin-regex": "^16.5.0",
         "@lvce-editor/eslint-plugin-tsconfig": "^16.5.0",
@@ -2944,9 +2944,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.5.0.tgz",
-      "integrity": "sha512-jRVb67XrN9MnhpR9tPbkN5R3N9hb+u95Oj2GWNNtHDDMqmm0RnQkj44SUxkDsLXwjguqG6Kxj6WkqX7XKuAN0w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.3.tgz",
+      "integrity": "sha512-ChzOGQfCDANWLZlaR05tO6880FDTz9RZ+ATbijYSEByVDzdMSCgoDBPOzOXKDyCpeIR6KZ2I+O80mvNKTYlEgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2956,14 +2956,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.5.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.5.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.5.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.5.0",
-        "@lvce-editor/eslint-plugin-regex": "16.5.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.5.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.5.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.5.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.3",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.3",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.3",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.3",
+        "@lvce-editor/eslint-plugin-regex": "17.0.3",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.3",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.3",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.3",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2977,10 +2977,38 @@
         "eslint": "^10"
       }
     },
+    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-github-actions": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.3.tgz",
+      "integrity": "sha512-+LMl161bH/f6iS4H+Uc/9lkZnF7jZOxChV2ghn0u9v3326r0rIfbE2eUiaWWZIxh2ox1qWXPWyGhyqxkdkUBjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-compat-utils": "0.6.5",
+        "yaml-eslint-parser": "2.1.0"
+      }
+    },
+    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-regex": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.3.tgz",
+      "integrity": "sha512-QcDlgWoQdTkdt3CIINvQ+ZzKUJeYvPXq1s7AInPpqVHvkpmJAOkOst3lFDRNnLDcbW7HR3iynhzC54TqUNOqnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-tsconfig": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.3.tgz",
+      "integrity": "sha512-eXADQLKjL0eGvYItn0yKfZIGjnide4Su9emR7tsKTNsSHowEPX5IMfk+z90106xsR9G33kTutre2o94AOSihkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/json": "2.0.1"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.5.0.tgz",
-      "integrity": "sha512-cxFhq3mzv4dCQi0HcGf1HibTNAcifkF9HAM2v9QGHVyzHicF23SEAVXbpPzZYQ8y1U6xB9hlzppXNuPDcLUxFA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.3.tgz",
+      "integrity": "sha512-9lKoUZZitH134WxgfjGsYS8I2p5/e2bdwMCAtSuc31+a9Q/atpRSqStUSlsyumRxt781lgRdUvn9/jhGzTEoUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2988,9 +3016,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.5.0.tgz",
-      "integrity": "sha512-lPTC+X6msmkRVfYzFGyWJzK4Dm4t7woQQtVTkosTnEeg8SCYTyAqbt7cc6Bt0NhrLtSnZocZiZT6gYbJ6877PA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.3.tgz",
+      "integrity": "sha512-vE+DWFSlacnLOtHEhp5YS3q8Z0s0OQOBKYDvXG8g8fHyMGEQ2HFkE+WcIBe3LejQ39F2edh+y+vEs8xPgL8u0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3006,9 +3034,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.5.0.tgz",
-      "integrity": "sha512-50iv6im3U/W8JsS2dvgWhwNeiWfAMCh2kc9EgsmHQ5zdXmjcUmlkDU2rAKQriQsi3U3uZdWpFBCz6khdNAeq5w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.3.tgz",
+      "integrity": "sha512-KmcXC9mDB5a6aAYon+OP60ybRmfdlShu8EefEbkm+pL3+ZBvOBpaj0haHnCTD2sXBBiZCPqBsyIK6kuZSsVg0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3023,9 +3051,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.5.0.tgz",
-      "integrity": "sha512-30OYviUIhK+2bsvl7UHXohPj4hPqR5XAayYsiSwfDRZGaqga7CVW7Zo89hKdE6lDIT1GrqE3OlpW1YzD6w5V1w==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.3.tgz",
+      "integrity": "sha512-LATOZfFUtuweBsCHJr8EpZv9CnKyFTKQ/JCPK8z3dHGXv/313pmGamN+N7qMioMXnzAL6M5OFRFpA2yBEU6euw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3040,9 +3068,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.5.0.tgz",
-      "integrity": "sha512-x2ReJ0CfNxXF/1BfsdUVOZTf/8kaWjRS8HEsDnfLQ7dzvpdMOGFQBUc0STO/tUmY1TOK9SMlMIUnbNNwH0OEyQ==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.3.tgz",
+      "integrity": "sha512-HbcAuxZ/8ZltmOanAqqpqsmL5YZh6kOQZXcyEtH0Xl+xkRJlC3hS2KAEtWDANsHYZJsbM6S7fR4pdORcgiHcKg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^16.5.0",
+    "@lvce-editor/eslint-config": "^17.0.3",
     "@lvce-editor/eslint-plugin-github-actions": "^16.5.0",
     "@lvce-editor/eslint-plugin-regex": "^16.5.0",
     "@lvce-editor/eslint-plugin-tsconfig": "^16.5.0",

--- a/packages/explorer-view/src/parts/GetExplorerWelcomeVirtualDom/GetExplorerWelcomeVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetExplorerWelcomeVirtualDom/GetExplorerWelcomeVirtualDom.ts
@@ -9,6 +9,18 @@ import * as TabIndex from '../TabIndex/TabIndex.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 import { text } from '../VirtualDomHelpers/VirtualDomHelpers.ts'
 
+const welcomeNode: VirtualDomNode = {
+  childCount: 2,
+  className: ClassNames.Welcome,
+  type: VirtualDomElements.Div,
+}
+
+const welcomeMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.WelcomeMessage,
+  type: VirtualDomElements.P,
+}
+
 const getClassName = (dropTargets: readonly number[]): string => {
   const extraClassName = dropTargets === dropTargetFull ? ClassNames.ExplorerDropTarget : ClassNames.Empty
   return MergeClassNames.mergeClassNames(ClassNames.Viewlet, ClassNames.Explorer, extraClassName)
@@ -26,16 +38,8 @@ export const getExplorerWelcomeVirtualDom = (isWide: boolean, dropTargets: reado
       tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 2,
-      className: ClassNames.Welcome,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 1,
-      className: ClassNames.WelcomeMessage,
-      type: VirtualDomElements.P,
-    },
+    welcomeNode,
+    welcomeMessageNode,
     text(ExplorerStrings.youHaveNotYetOpenedAFolder()),
     {
       childCount: 1,

--- a/packages/explorer-view/src/parts/GetLoadErrorVirtualDom/GetLoadErrorVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetLoadErrorVirtualDom/GetLoadErrorVirtualDom.ts
@@ -8,6 +8,12 @@ import * as InputName from '../InputName/InputName.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
+const welcomeMessageNode: VirtualDomNode = {
+  childCount: 1,
+  className: ClassNames.WelcomeMessage,
+  type: VirtualDomElements.P,
+}
+
 const getParentNode = (childCount: number): VirtualDomNode => {
   return {
     childCount,
@@ -29,11 +35,7 @@ export const getLoadErrorVirtualDom = (
       className: ClassNames.Welcome,
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 1,
-      className: ClassNames.WelcomeMessage,
-      type: VirtualDomElements.P,
-    },
+    welcomeMessageNode,
     text(loadErrorMessage),
   ]
   const buttonDom = showOpenAnotherFolderButton

--- a/packages/explorer-view/src/parts/GetScrollBarVirtualDom/GetScrollBarVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetScrollBarVirtualDom/GetScrollBarVirtualDom.ts
@@ -3,6 +3,12 @@ import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as MergeClassNames from '../MergeClassNames/MergeClassNames.ts'
 import * as VirtualDomElements from '../VirtualDomElements/VirtualDomElements.ts'
 
+const scrollBarThumbNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ScrollBarThumb,
+  type: VirtualDomElements.Div,
+}
+
 export const getScrollBarVirtualDom = (scrollBarHeight: number): readonly VirtualDomNode[] => {
   const shouldShowScrollbar = scrollBarHeight > 0
   if (!shouldShowScrollbar) {
@@ -14,10 +20,6 @@ export const getScrollBarVirtualDom = (scrollBarHeight: number): readonly Virtua
       className: MergeClassNames.mergeClassNames(ClassNames.ScrollBar, ClassNames.ScrollBarSmall),
       type: VirtualDomElements.Div,
     },
-    {
-      childCount: 0,
-      className: ClassNames.ScrollBarThumb,
-      type: VirtualDomElements.Div,
-    },
+    scrollBarThumbNode,
   ]
 }


### PR DESCRIPTION
Update ESLint and the shared config, then hoist static explorer virtual DOM nodes required by the latest lint rule while keeping localized text dynamic.