### PR TITLE
feature: add 20 more explorer e2e tests

### DIFF
--- a/packages/e2e/src/viewlet.explorer-case-only-rename-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-case-only-rename-folder.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-case-only-rename-folder'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('Folder')
+  await Explorer.acceptEdit()
+
+  const original = Locator('.TreeItem[aria-label="folder"]')
+  const renamed = Locator('.TreeItem[aria-label="Folder"]')
+  await expect(original).toBeHidden()
+  await expect(renamed).toBeVisible()
+  await expect(renamed).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-create-folder-starting-with-dot.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-starting-with-dot.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-create-folder-starting-with-dot'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('.config')
+  await Explorer.acceptEdit()
+
+  const folder = Locator('.TreeItem[aria-label=".config"]')
+  await expect(folder).toBeVisible()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(folder).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-create-folder-with-emoji.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-with-emoji.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-create-folder-with-emoji'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('project-🚀')
+  await Explorer.acceptEdit()
+
+  const folder = Locator('.TreeItem[aria-label="project-🚀"]')
+  await expect(folder).toBeVisible()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(folder).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-create-folder-with-greek-characters.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-with-greek-characters.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-create-folder-with-greek-characters'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('δοκιμή')
+  await Explorer.acceptEdit()
+
+  const folder = Locator('.TreeItem[aria-label="δοκιμή"]')
+  await expect(folder).toBeVisible()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(folder).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-create-folder-with-spaces.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-with-spaces.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-create-folder-with-spaces'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('folder with spaces')
+  await Explorer.acceptEdit()
+
+  const folder = Locator('.TreeItem[aria-label="folder with spaces"]')
+  await expect(folder).toBeVisible()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(folder).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-create-folder-with-special-characters.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-with-special-characters.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-create-folder-with-special-characters'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.setPath(tmpDir)
+
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('docs & notes (draft)')
+  await Explorer.acceptEdit()
+
+  const folder = Locator('.TreeItem[aria-label="docs & notes (draft)"]')
+  await expect(folder).toBeVisible()
+  await expect(folder).toHaveAttribute('aria-expanded', 'false')
+  await expect(folder).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-rename-folder-starting-with-dot.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-folder-starting-with-dot.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-rename-folder-starting-with-dot'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('.settings')
+  await Explorer.acceptEdit()
+
+  const original = Locator('.TreeItem[aria-label="folder"]')
+  const renamed = Locator('.TreeItem[aria-label=".settings"]')
+  await expect(original).toBeHidden()
+  await expect(renamed).toBeVisible()
+  await expect(renamed).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-rename-folder-with-emoji.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-folder-with-emoji.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-rename-folder-with-emoji'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('archive-📦')
+  await Explorer.acceptEdit()
+
+  const original = Locator('.TreeItem[aria-label="folder"]')
+  const renamed = Locator('.TreeItem[aria-label="archive-📦"]')
+  await expect(original).toBeHidden()
+  await expect(renamed).toBeVisible()
+  await expect(renamed).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-rename-folder-with-greek-characters.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-folder-with-greek-characters.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-rename-folder-with-greek-characters'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('φάκελος')
+  await Explorer.acceptEdit()
+
+  const original = Locator('.TreeItem[aria-label="folder"]')
+  const renamed = Locator('.TreeItem[aria-label="φάκελος"]')
+  await expect(original).toBeHidden()
+  await expect(renamed).toBeVisible()
+  await expect(renamed).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-rename-folder-with-spaces.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-folder-with-spaces.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-rename-folder-with-spaces'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('renamed folder')
+  await Explorer.acceptEdit()
+
+  const original = Locator('.TreeItem[aria-label="folder"]')
+  const renamed = Locator('.TreeItem[aria-label="renamed folder"]')
+  await expect(original).toBeHidden()
+  await expect(renamed).toBeVisible()
+  await expect(renamed).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-cycle-after-reset.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-cycle-after-reset.ts
@@ -1,0 +1,22 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-cycle-after-reset'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/banana.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/berry.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  const banana = Locator('.TreeItem[aria-label="banana.txt"]')
+  await expect(banana).toHaveId('TreeItemActive')
+
+  await Command.execute('Explorer.handleKeyDown', false, '')
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+
+  const berry = Locator('.TreeItem[aria-label="berry.txt"]')
+  await expect(berry).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-default-prevented.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-default-prevented.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-default-prevented'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', true, 'b')
+
+  const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
+  await expect(alpha).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-folder-prefix.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-folder-prefix.ts
@@ -1,0 +1,17 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-folder-prefix'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/alpha`)
+  await FileSystem.mkdir(`${tmpDir}/beta`)
+  await FileSystem.writeFile(`${tmpDir}/charlie.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusLast()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+
+  const beta = Locator('.TreeItem[aria-label="beta"]')
+  await expect(beta).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-multiple-character-prefix.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-multiple-character-prefix.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-multiple-character-prefix'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/banana.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/berry.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/brick.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Command.execute('Explorer.handleKeyDown', false, 'r')
+
+  const brick = Locator('.TreeItem[aria-label="brick.txt"]')
+  await expect(brick).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-nested-child.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-nested-child.ts
@@ -1,0 +1,18 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-nested-child'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/root.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.expandRecursively()
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'c')
+
+  const child = Locator('.TreeItem[aria-label="child.txt"]')
+  await expect(child).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-no-match-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-no-match-keeps-focus.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-no-match-keeps-focus'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(1)
+
+  await Command.execute('Explorer.handleKeyDown', false, 'z')
+
+  const beta = Locator('.TreeItem[aria-label="beta.txt"]')
+  await expect(beta).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-non-ascii-ignored.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-non-ascii-ignored.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-non-ascii-ignored'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/éclair.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'é')
+
+  const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
+  await expect(alpha).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-reset-word.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-reset-word.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-reset-word'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/charlie.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Command.execute('Explorer.handleKeyDown', false, '')
+  await Command.execute('Explorer.handleKeyDown', false, 'c')
+
+  const charlie = Locator('.TreeItem[aria-label="charlie.txt"]')
+  await expect(charlie).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-substring-does-not-match.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-substring-does-not-match.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-substring-does-not-match'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/snap.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(1)
+
+  await Command.execute('Explorer.handleKeyDown', false, 'a')
+
+  const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
+  await expect(alpha).toHaveId('TreeItemActive')
+}

--- a/packages/e2e/src/viewlet.explorer-typeahead-uppercase.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-uppercase.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-typeahead-uppercase'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
+  await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusFirst()
+
+  await Command.execute('Explorer.handleKeyDown', false, 'B')
+
+  const beta = Locator('.TreeItem[aria-label="beta.txt"]')
+  await expect(beta).toHaveId('TreeItemActive')
+}


### PR DESCRIPTION
Adds 20 active explorer end-to-end tests covering folder-name handling during create and rename operations, plus type-ahead navigation behavior.