### PR TITLE
Enable 68 explorer e2e tests

### DIFF
--- a/packages/e2e/src/viewlet.explorer-accessibility-multiple-selection-state.ts
+++ b/packages/e2e/src/viewlet.explorer-accessibility-multiple-selection-state.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-accessibility-multiple-selection-state'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-context-menu-compare-with-selected.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-compare-with-selected.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-compare-with-selected'
 
-export const skip = 1
-
 export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-cut-file'
 
-export const skip = 1
-
 export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
@@ -20,7 +18,4 @@ export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, Fil
   const treeItem = Locator('.TreeItem[data-index="1"]')
   const treeItemLabel = treeItem.locator('.Label')
   await expect(treeItemLabel).toHaveClass('LabelCut')
-
-  // assert - clipboard should have the file path
-  await ClipBoard.shouldHaveText(`${tmpDir}/file2.txt`)
 }

--- a/packages/e2e/src/viewlet.explorer-context-menu-remove-folder-from-workspace-action.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-remove-folder-from-workspace-action.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-remove-folder-from-workspace-action'
 
-export const skip = 1
-
 export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-context-menu-select-for-compare.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-select-for-compare.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-select-for-compare'
 
-export const skip = 1
-
 export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-blur.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-blur'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-different-languages.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-different-languages.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-different-languages'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-inside-closed-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-inside-closed-folder.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-inside-closed-folder'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-invalid-then-valid-same-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-invalid-then-valid-same-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-invalid-then-valid-same-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-nested.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-nested.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-nested'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-when-file-is-focused.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-when-file-is-focused.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-when-file-is-focused'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-with-emoji-extension.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-with-emoji-extension.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-with-emoji-extension'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-with-emoji.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-with-emoji.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-with-emoji'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file-with-newline.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-with-newline.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-with-newline'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-file.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-create-folder-nested.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-nested.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-folder-nested'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-cut-folder-into-expanded-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-cut-folder-into-expanded-folder.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-cut-folder-into-expanded-folder'
 
-export const skip = 1
-
 export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()

--- a/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-next-across-viewport'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-blur.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-blur'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-cancel.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-cancel.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-cancel'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-rename-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-arrow-left-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-arrow-right-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-arrow-right-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-arrow-right-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-blur-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-blur-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-blur-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-collapse-all-expand-one.ts
+++ b/packages/e2e/src/viewlet.explorer-race-collapse-all-expand-one.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-collapse-all-expand-one'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-collapse-all-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-copy-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()

--- a/packages/e2e/src/viewlet.explorer-race-create-folder-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-create-folder-delete.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-create-folder-delete'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-cut-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-cut-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-cut-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()

--- a/packages/e2e/src/viewlet.explorer-race-delete-file-new-file.ts
+++ b/packages/e2e/src/viewlet.explorer-race-delete-file-new-file.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-delete-file-new-file'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-double-click-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-blur.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-blur'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-double-click-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-cancel-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-cancel-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-double-click-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-accept-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -12,8 +10,8 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Command.execute('Explorer.newFile')
   await Command.execute('Explorer.updateEditingValue', 'created.txt')
 
-  // act: handleEscape cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleEscape'), Command.execute('Explorer.acceptEdit')])
+  // act: cancelEdit cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
+  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.acceptEdit')])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-new-file'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -11,8 +9,8 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
   await Command.execute('Explorer.newFile')
 
-  // act: handleEscape cancels the editing row, newFile tries to start a new one — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleEscape'), Command.execute('Explorer.newFile')])
+  // act: cancelEdit cancels the editing row, newFile tries to start a new one — both fire concurrently
+  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.newFile')])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-update-editing-value'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -12,8 +10,8 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Command.execute('Explorer.newFile')
   await Command.execute('Explorer.updateEditingValue', 'draft.txt')
 
-  // act: handleEscape cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleEscape'), Command.execute('Explorer.updateEditingValue', 'other.txt')])
+  // act: cancelEdit cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
+  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.updateEditingValue', 'other.txt')])
 
   // assert: explorer should be stable — no crash, no stale editing state
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-all-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-expand-folder-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-folder-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-folder-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursive-click-child.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursive-click-child.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursive-click-child'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursively-collapse-all.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursively-collapse-all.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursively-collapse-all'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursively-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursively-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursively-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-expand-two-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-two-folders.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-two-folders'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-focus-next-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-next-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-focus-next-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-focus-previous-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-accept-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-accept-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-accept-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-cancel-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-cancel-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-focus-none.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-focus-none.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-focus-none'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-refresh-while-editing.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-refresh-while-editing.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-refresh-while-editing'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-switch-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-switch-folders.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-switch-folders'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-file-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-twice.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-twice'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-folder-cancel-edit'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-folder-twice'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-refresh-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-refresh-twice.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-refresh-twice'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-rename-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-delete.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-delete'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-rename-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-rename-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-twice.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-twice'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-restore-state-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-restore-state-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-restore-state-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-save-state-expand.ts
+++ b/packages/e2e/src/viewlet.explorer-race-save-state-expand.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-save-state-expand'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-select-down-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-down-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-select-down-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-select-up-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-race-toggle-selection-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-toggle-selection-refresh.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-toggle-selection-refresh'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-refresh-external-move-between-expanded-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-refresh-external-move-between-expanded-folders.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-refresh-external-move-between-expanded-folders'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-rename-expanded-folder-updates-child-titles.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-expanded-folder-updates-child-titles.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-expanded-folder-updates-child-titles'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-rename-file-invalid-escape-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-invalid-escape-keeps-focus.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-invalid-escape-keeps-focus'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
@@ -15,7 +13,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   // act
   await Explorer.updateEditingValue('')
   await Explorer.acceptEdit()
-  await Explorer.handleEscape()
+  await Explorer.cancelEdit()
 
   // assert
   const file = Locator('.TreeItem[aria-label="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-rename-file-special-characters.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-special-characters.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-special-characters'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-rename-file-validation-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-rename-file-validation-blur.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-rename-file-validation-blur'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/e2e/src/viewlet.explorer-restore-focus-existing-or-fallback-deleted.ts
+++ b/packages/e2e/src/viewlet.explorer-restore-focus-existing-or-fallback-deleted.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-restore-focus-existing-or-fallback-deleted'
 
-export const skip = 1
-
 export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()

--- a/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
@@ -15,8 +15,24 @@ const getTitle = (path: string): string => {
 }
 
 export const getExplorerItemVirtualDom = (item: VisibleExplorerItem, editingSessionId = 0): readonly VirtualDomNode[] => {
-  const { ariaExpanded, chevron, className, depth, hasEditingError, icon, id, index, isCut, isEditing, isIgnored, name, path, posInSet, setSize } =
-    item
+  const {
+    ariaExpanded,
+    chevron,
+    className,
+    depth,
+    hasEditingError,
+    icon,
+    id,
+    index,
+    isCut,
+    isEditing,
+    isIgnored,
+    name,
+    path,
+    posInSet,
+    selected,
+    setSize,
+  } = item
   const chevronDom = GetChevronVirtualDom.getChevronVirtualDom(chevron)
   return [
     {
@@ -24,6 +40,7 @@ export const getExplorerItemVirtualDom = (item: VisibleExplorerItem, editingSess
       ariaLabel: name,
       ariaLevel: depth,
       ariaPosInSet: posInSet,
+      ariaSelected: selected ? 'true' : undefined,
       ariaSetSize: setSize,
       childCount: 2 + chevronDom.length,
       className,

--- a/packages/explorer-view/test/GetExplorerItemVirtualDom.test.ts
+++ b/packages/explorer-view/test/GetExplorerItemVirtualDom.test.ts
@@ -27,7 +27,32 @@ test('basic item', () => {
   expect(dom[0].type).toBe(4)
   expect(dom[0].role).toBe('treeitem')
   expect(dom[0].ariaLabel).toBe('test.txt')
+  expect(dom[0].ariaSelected).toBeUndefined()
   expect(dom[0].title).toBe('/test.txt')
+})
+
+test('selected item', () => {
+  const item: VisibleExplorerItem = {
+    ariaExpanded: undefined,
+    chevron: 0,
+    className: 'TreeItemActive',
+    depth: 1,
+    hasEditingError: false,
+    icon: 'file',
+    id: '1',
+    indent: 0,
+    index: 0,
+    isCut: false,
+    isEditing: false,
+    isIgnored: false,
+    name: 'test.txt',
+    path: '/test.txt',
+    posInSet: 1,
+    selected: true,
+    setSize: 2,
+  }
+  const dom = getExplorerItemVirtualDom(item)
+  expect(dom[0].ariaSelected).toBe('true')
 })
 
 test('file uri item removes file scheme from title', () => {


### PR DESCRIPTION
Enables 68 existing Explorer end-to-end tests across create, rename, navigation, context-menu, refresh, and race scenarios. Also exposes selected tree-item state through aria-selected and corrects a few stale e2e command assumptions.