### PR TITLE
feature: use typed e2e page objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3055,9 +3055,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.92.0.tgz",
-      "integrity": "sha512-KxLQ2LaiBsCpPHJk/EKelRp7taQZINNfz9y2l9ofEICf7M5mP3MN5j9GOYw9dFBzx1v49FtLXsEIS6sfBwROFQ==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.0.tgz",
+      "integrity": "sha512-uKecWqRzfPOVAx4rUadpu3FMDDK04hkd0LToO4HFeY3LVhrDJGRdOR/XBiNff12WoIh/m84ulgKLNSCiYEQV5A==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -4008,13 +4008,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.92.0.tgz",
-      "integrity": "sha512-6vzbZKRGwXBvlsp/FfhgW2H6nEeI69U4fUOZMO/Rq4zBIKWLT0o67tOMaggvd2qOP/IxXMpT7u/5A3Squ78l/w==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.0.tgz",
+      "integrity": "sha512-TYrN6fLlo0M0X58GZoCoLJo6P2x3lvwvmqCPxPjP2fJYvEOv0A0jRP5V5diIc0yzCUxmyy0tV/fJS831NuL2BQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.92.0",
-        "@lvce-editor/static-server": "0.92.0"
+        "@lvce-editor/shared-process": "0.93.0",
+        "@lvce-editor/static-server": "0.93.0"
       },
       "bin": {
         "server": "bin/server.js"
@@ -4024,14 +4024,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.92.0.tgz",
-      "integrity": "sha512-iVjvyJLS1zTC8gzQDy4MgTRcr0aTqwodNsWiNwbe4UboVbLdHp9mq2STZFSka92lza9NtFZruwIY27CrvqKfCw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.0.tgz",
+      "integrity": "sha512-z72QQDubP0dTlEpX85wDYhxZ5yBv1tUXkQSxbzjs/2za0WiiLP+jVrw/gpW7S/hPXiR+WL82Y+KsE8KznqTtuQ==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.92.0",
+        "@lvce-editor/extension-host-helper-process": "0.93.0",
         "@lvce-editor/ipc": "16.4.0",
         "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -4063,23 +4063,23 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.92.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.92.0.tgz",
-      "integrity": "sha512-C4l290pq3LTADDJgWxJaVY8PcYsgP1tkHjuqePOmaYbKZjLzQnaNwsOdluGOgv0KRPrk0LpOhPC/qLASjB1tDw==",
+      "version": "0.93.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.0.tgz",
+      "integrity": "sha512-na0ES8iqgF+N7BcwZu0pDgFL0GpNhYUUoApNHqvdEEcgARQWq8VjnbwtYMmFRVvtUBH+O4ioYhoGqex0mjiqyg==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.9.0.tgz",
-      "integrity": "sha512-I9v2B7lCKfNK5DRgBQJ5YmM2nlE/uYCJ3qrwpVUYYRjigTb5offGevfCJ1P6paDd3iCt/Z53FB3AW+dGx2Xj2w==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.10.0.tgz",
+      "integrity": "sha512-TSa1MIZJvNk5I98YnFV3GxoQ5uEaKdveiPdkQjrSG+k/wFhXtfh5zOQj+eRlyliTJZTp66UxXfo8t80SrZzbEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.9.0",
-        "@lvce-editor/test-worker": "^17.4.1"
+        "@lvce-editor/test-with-playwright-worker": "22.10.0",
+        "@lvce-editor/test-worker": "^17.5.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
@@ -4089,9 +4089,9 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.9.0.tgz",
-      "integrity": "sha512-Q3v4k/PFfBv2/4kspbHWMSJxe71hyAX1oy+DDpt/5mYBrNGGQlo++4XCfajZLbiO8xdXQoNg6jafI7Ot/XznXg==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.10.0.tgz",
+      "integrity": "sha512-4LWO0qXe+ZOh8FEn+8c5/7ZC7o3gMN4lOGbE5xHHldSF1kuTFcUgqkpViOgZDzjGt1Z3aB4ZrbK+pvDQpqsRRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17236,7 +17236,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.9.0"
+        "@lvce-editor/test-with-playwright": "^22.10.0"
       }
     },
     "packages/explorer-view": {
@@ -17263,7 +17263,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.92.0"
+        "@lvce-editor/server": "0.93.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4107,9 +4107,9 @@
       }
     },
     "node_modules/@lvce-editor/test-worker": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.4.2.tgz",
-      "integrity": "sha512-MfjungmpT7y550fJMMza9hhUIalN16mayTxGNxv59c06UzW2NiYEU8Fkcd/eyMreb/xtVn6pEKjeaEEfSo9NiQ==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.5.0.tgz",
+      "integrity": "sha512-TM4uisYLRVQdktjZ4LZsGcmd8bel/bUlNYrh063Po3VG6PYj5+81IAUT3NjQmuJp38Y2VO5g0GPY/EygNAY/jQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -13,6 +13,6 @@
     "type-check": "tsc"
   },
   "devDependencies": {
-    "@lvce-editor/test-with-playwright": "^22.9.0"
+    "@lvce-editor/test-with-playwright": "^22.10.0"
   }
 }

--- a/packages/e2e/src/viewlet.explorer-arrow-left-collapsed-nested-folder-focuses-parent.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-collapsed-nested-folder-focuses-parent.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-collapsed-nested-folder-focuses-parent'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/parent/child`)
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(1)
 
   // act
-  await Command.execute('Explorer.handleArrowLeft')
+  await Explorer.handleArrowLeft()
 
   // assert
   const parent = Locator('.TreeItem[aria-label="parent"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-left-expanded-folder-collapses.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-expanded-folder-collapses.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-expanded-folder-collapses'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.clickCurrent()
 
   // act
-  await Command.execute('Explorer.handleArrowLeft')
+  await Explorer.handleArrowLeft()
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-left-expanded-top-level-folder-keeps-root-sibling-visible.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-expanded-top-level-folder-keeps-root-sibling-visible.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-expanded-top-level-folder-keeps-root-sibling-visible'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   await Explorer.handleArrowLeft()
 

--- a/packages/e2e/src/viewlet.explorer-arrow-left-nested-file-focuses-parent.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-nested-file-focuses-parent.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-nested-file-focuses-parent'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(1)
 
   // act
-  await Command.execute('Explorer.handleArrowLeft')
+  await Explorer.handleArrowLeft()
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-left-no-focus-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-no-focus-no-op.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-no-focus-no-op'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, '')
   await Workspace.setPath(tmpDir)
 
   // act
-  await Command.execute('Explorer.handleArrowLeft')
+  await Explorer.handleArrowLeft()
 
   // assert
   const file = Locator('.TreeItem[aria-label="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-left-top-level-file-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-left-top-level-file-no-op.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-left-top-level-file-no-op'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(0)
 
   // act
-  await Command.execute('Explorer.handleArrowLeft')
+  await Explorer.handleArrowLeft()
 
   // assert
   const file = Locator('.TreeItem[aria-label="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-empty-expanded-folder-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-empty-expanded-folder-keeps-focus.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-empty-expanded-folder-keeps-focus'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.clickCurrent()
 
   // act
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-expanded-folder-focuses-sorted-first-child.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-expanded-folder-focuses-sorted-first-child.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-expanded-folder-focuses-sorted-first-child'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/z.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/folder/a.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   const firstChild = Locator('.TreeItem[aria-label="a.txt"]')
   const secondChild = Locator('.TreeItem[aria-label="z.txt"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-expanding-one-folder-keeps-sibling-collapsed.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-expanding-one-folder-keeps-sibling-collapsed.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-expanding-one-folder-keeps-sibling-collapsed'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
   await FileSystem.mkdir(`${tmpDir}/b`)
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
 
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   const firstFolder = Locator('.TreeItem[aria-label="a"]')
   const secondFolder = Locator('.TreeItem[aria-label="b"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-expands-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-expands-folder.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-expands-folder'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(0)
 
   // act
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-file-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-file-no-op.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-file-no-op'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(0)
 
   // act
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   // assert
   const file = Locator('.TreeItem[aria-label="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-focuses-first-child.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-focuses-first-child.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-focuses-first-child'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.clickCurrent()
 
   // act
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-nested-expanded-folder-focuses-first-child.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-nested-expanded-folder-focuses-first-child.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-nested-expanded-folder-focuses-first-child'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/parent/child`)
   await FileSystem.writeFile(`${tmpDir}/parent/child/file.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
-  await Command.execute('Explorer.handleArrowRight')
-  await Command.execute('Explorer.handleArrowRight')
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
+  await Explorer.handleArrowRight()
+  await Explorer.handleArrowRight()
 
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   const file = Locator('.TreeItem[aria-label="file.txt"]')
   await expect(file).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-arrow-right-nested-folder-expands.ts
+++ b/packages/e2e/src/viewlet.explorer-arrow-right-nested-folder-expands.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-arrow-right-nested-folder-expands'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/parent/child`)
   await FileSystem.writeFile(`${tmpDir}/parent/child/file.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
-  await Command.execute('Explorer.handleArrowRight')
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
+  await Explorer.handleArrowRight()
 
-  await Command.execute('Explorer.handleArrowRight')
+  await Explorer.handleArrowRight()
 
   const child = Locator('.TreeItem[aria-label="child"]')
   const file = Locator('.TreeItem[aria-label="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-copy-paste-error-scenarios.ts
+++ b/packages/e2e/src/viewlet.explorer-copy-paste-error-scenarios.ts
@@ -3,7 +3,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'viewlet.explorer-copy-paste-error-scenarios'
 export const skip = 1
 
-export const test: Test = async ({ ClipBoard, Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -16,7 +16,7 @@ export const test: Test = async ({ ClipBoard, Command, expect, Explorer, FileSys
   await Explorer.focusIndex(1)
 
   // Test 1: Copy file to read-only directory
-  await Command.execute('FileSystem.setReadOnly', `${tmpDir}/target`, true)
+  await FileSystem.setReadOnly(`${tmpDir}/target`, true)
   await Explorer.handleCopy()
   await Explorer.focusIndex(2)
   await Explorer.handlePaste()
@@ -31,9 +31,9 @@ export const test: Test = async ({ ClipBoard, Command, expect, Explorer, FileSys
   await expect(errorMessage).toBeVisible()
 
   // Test 3: Copy non-existent file (simulate file deletion after copy)
-  await Command.execute('FileSystem.setReadOnly', `${tmpDir}/target`, false)
+  await FileSystem.setReadOnly(`${tmpDir}/target`, false)
   await Explorer.handleCopy()
-  await Command.execute('FileSystem.deleteFile', `${tmpDir}/source/file.txt`)
+  await FileSystem.deleteFile(`${tmpDir}/source/file.txt`)
   await Explorer.focusIndex(2)
   await Explorer.handlePaste()
 

--- a/packages/e2e/src/viewlet.explorer-create-file-double-click-empty-space-race-condition.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-double-click-empty-space-race-condition.ts
@@ -2,17 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-double-click-empty-space'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act
-  await Promise.all([
-    Command.execute('Explorer.handleClickAt', false, 0, false, false, 20, 100),
-    Command.execute('Explorer.handleDoubleClick', 20, 100),
-  ])
+  await Promise.all([Explorer.handleClickAt(false, 0, false, false, 20, 100), Explorer.handleDoubleClick(20, 100)])
 
   // assert
   const inputBox = Locator('.Explorer input')

--- a/packages/e2e/src/viewlet.explorer-create-file-double-click-empty-space.ts
+++ b/packages/e2e/src/viewlet.explorer-create-file-double-click-empty-space.ts
@@ -2,15 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-double-click-empty-space'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act
-  await Command.execute('Explorer.handleClickAt', false, 0, false, false, 20, 100)
-  await Command.execute('Explorer.handleDoubleClick', 20, 100)
+  await Explorer.handleClickAt(false, 0, false, false, 20, 100)
+  await Explorer.handleDoubleClick(20, 100)
 
   // assert
   const inputBox = Locator('.Explorer input')

--- a/packages/e2e/src/viewlet.explorer-create-folder-double-click-empty-space.ts
+++ b/packages/e2e/src/viewlet.explorer-create-folder-double-click-empty-space.ts
@@ -2,15 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-create-file-double-click-empty-space'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act
-  await Command.execute('Explorer.handleClickAt', false, 0, false, false, 20, 100)
-  await Command.execute('Explorer.handleDoubleClick', 20, 100)
+  await Explorer.handleClickAt(false, 0, false, false, 20, 100)
+  await Explorer.handleDoubleClick(20, 100)
 
   // assert
   const inputBox = Locator('.Explorer input')

--- a/packages/e2e/src/viewlet.explorer-double-click-file-opens-permanently.ts
+++ b/packages/e2e/src/viewlet.explorer-double-click-file-opens-permanently.ts
@@ -2,12 +2,12 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-double-click-file-opens-permanently'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/test.txt`, 'content')
   await Workspace.setPath(tmpDir)
 
-  await Command.execute('Explorer.handleDoubleClick', 20, 10)
+  await Explorer.handleDoubleClick(20, 10)
 
   const editorTab = Locator('.MainTab:not(.MainTabPreview)[title$="test.txt"]')
   await expect(editorTab).toBeVisible()

--- a/packages/e2e/src/viewlet.explorer-drag-drop-error-scenarios.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-drop-error-scenarios.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-drag-drop-error-scenarios'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -13,13 +13,13 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
 
   // Test 1: Drop file on read-only directory
-  await Command.execute('FileSystem.setReadOnly', `${tmpDir}/readonly-dir`, true)
+  await FileSystem.setReadOnly(`${tmpDir}/readonly-dir`, true)
 
   const directory = await navigator.storage.getDirectory()
   const fileHandle = await directory.getFileHandle('test-file.txt', { create: true })
   const file = await fileHandle.getFile()
   const fileList = [file]
-  const id = await Command.execute('FileSystemHandle.addFileHandle', fileHandle)
+  const id = await FileSystem.registerFileHandle(fileHandle)
 
   // Try to drop on read-only directory
   await Explorer.handleDrop(2, 0, [id], fileList)
@@ -37,7 +37,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(errorMessage).toBeVisible()
 
   // Test 3: Drop file on itself (same location)
-  await Command.execute('FileSystem.setReadOnly', `${tmpDir}/readonly-dir`, false)
+  await FileSystem.setReadOnly(`${tmpDir}/readonly-dir`, false)
   await Explorer.handleDrop(0, 0, [id], fileList)
 
   // Should handle or show appropriate message
@@ -48,10 +48,10 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   const fileHandle2 = await directory.getFileHandle('test-file2.txt', { create: true })
   const file2 = await fileHandle2.getFile()
   const fileList2 = [file, file2]
-  const id2 = await Command.execute('FileSystemHandle.addFileHandle', fileHandle2)
+  const id2 = await FileSystem.registerFileHandle(fileHandle2)
 
   // Delete one file after adding to handles to simulate error
-  await Command.execute('FileSystemHandle.removeFileHandle', id2)
+  await FileSystem.removeFileHandle(id2)
 
   await Explorer.handleDrop(0, 0, [id, 999_999], fileList2)
 

--- a/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
@@ -24,8 +24,6 @@ export const test: Test = async ({ Explorer, FileSystem, Workspace }) => {
   // const files = []
   // const paths = []
   // const index = 0
-  // await Command.execute('Explorer.handleDropIndex', fileHandles, files, paths, index)
-  // await Explorer.handleDrop()
-
+  // await Explorer.handleDropIndex(fileHandles, files, paths, index)
   // TODO drop file into folder and verify it is moved
 }

--- a/packages/e2e/src/viewlet.explorer-drag-folder-into-descendant.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-folder-into-descendant.ts
@@ -4,14 +4,14 @@ export const name = 'viewlet.explorer-drag-folder-into-descendant'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder/child`)
   await FileSystem.writeFile(`${tmpDir}/folder/child/file.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.expandRecursively()
-  const folderHandle = await Command.execute('FileSystemHandle.getDirectoryHandle', `${tmpDir}/folder`)
+  const folderHandle = await FileSystem.getDirectoryHandle(`${tmpDir}/folder`)
 
   // act
   await Explorer.handleDropIndex([folderHandle], [], [], 1)

--- a/packages/e2e/src/viewlet.explorer-drag-folder-into-itself.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-folder-into-itself.ts
@@ -4,13 +4,13 @@ export const name = 'viewlet.explorer-drag-folder-into-itself'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
   await Workspace.setPath(tmpDir)
-  const folderHandle = await Command.execute('FileSystemHandle.getDirectoryHandle', `${tmpDir}/folder`)
+  const folderHandle = await FileSystem.getDirectoryHandle(`${tmpDir}/folder`)
   await Explorer.focusFirst()
 
   // act

--- a/packages/e2e/src/viewlet.explorer-drop-file-and-folder-empty-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-drop-file-and-folder-empty-workspace.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drop-file-and-folder-empty-workspace'
 
-export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await Workspace.setPath('')
   const opfsRoot = await navigator.storage.getDirectory()
@@ -18,8 +18,8 @@ export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace
   const writable = await nestedFileHandle.createWritable({ keepExistingData: false })
   await writable.write('folder')
   await writable.close()
-  const fileId = await Command.execute('FileSystemHandle.addFileHandle', fileHandle)
-  const directoryId = await Command.execute('FileSystemHandle.addFileHandle', directoryHandle)
+  const fileId = await FileSystem.registerFileHandle(fileHandle)
+  const directoryId = await FileSystem.registerFileHandle(directoryHandle)
   const welcomeMessage = Locator('.Explorer .WelcomeMessage')
   const nestedFile = Locator('.TreeItem[aria-label="folder-inside.txt"]')
   const droppedFile = Locator('.TreeItem[aria-label="dropped-file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-drop-file-empty-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-drop-file-empty-workspace.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drop-file-empty-workspace'
 
-export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await Workspace.setPath('')
   const opfsRoot = await navigator.storage.getDirectory()
   const fileHandle = await opfsRoot.getFileHandle('dropped-file.txt', {
     create: true,
   })
-  const id = await Command.execute('FileSystemHandle.addFileHandle', fileHandle)
+  const id = await FileSystem.registerFileHandle(fileHandle)
   const welcomeMessage = Locator('.Explorer .WelcomeMessage')
   const treeItems = Locator('.TreeItem')
 

--- a/packages/e2e/src/viewlet.explorer-drop-folder-empty-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-drop-folder-empty-workspace.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drop-folder-empty-workspace'
 
-export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await Workspace.setPath('')
   const opfsRoot = await navigator.storage.getDirectory()
@@ -15,7 +15,7 @@ export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace
   const writable = await nestedFileHandle.createWritable({ keepExistingData: false })
   await writable.write('hello world')
   await writable.close()
-  const id = await Command.execute('FileSystemHandle.addFileHandle', directoryHandle)
+  const id = await FileSystem.registerFileHandle(directoryHandle)
   const welcomeMessage = Locator('.Explorer .WelcomeMessage')
 
   // act

--- a/packages/e2e/src/viewlet.explorer-drop-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-drop-folder.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drop-file'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/new`)
@@ -19,7 +19,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   const files: File[] = []
   const paths: string[] = []
   const index = 0
-  await Command.execute('Explorer.handleDropIndex', fileHandles, files, paths, index)
+  await Explorer.handleDropIndex(fileHandles, files, paths, index)
 
   // assert
   const newFolder = Locator('.TreeItem[aria-label="my first folder"]')

--- a/packages/e2e/src/viewlet.explorer-drop-two-folders-empty-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-drop-two-folders-empty-workspace.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drop-two-folders-empty-workspace'
 
-export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await Workspace.setPath('')
   const opfsRoot = await navigator.storage.getDirectory()
@@ -24,8 +24,8 @@ export const test: Test = async ({ Command, expect, Explorer, Locator, Workspace
   const secondWritable = await secondNestedFileHandle.createWritable({ keepExistingData: false })
   await secondWritable.write('second')
   await secondWritable.close()
-  const firstId = await Command.execute('FileSystemHandle.addFileHandle', firstDirectoryHandle)
-  const secondId = await Command.execute('FileSystemHandle.addFileHandle', secondDirectoryHandle)
+  const firstId = await FileSystem.registerFileHandle(firstDirectoryHandle)
+  const secondId = await FileSystem.registerFileHandle(secondDirectoryHandle)
   const welcomeMessage = Locator('.Explorer .WelcomeMessage')
   const firstNestedFile = Locator('.TreeItem[aria-label="first-inside.txt"]')
   const secondNestedFile = Locator('.TreeItem[aria-label="second-inside.txt"]')

--- a/packages/e2e/src/viewlet.explorer-file-system-provider-error.ts
+++ b/packages/e2e/src/viewlet.explorer-file-system-provider-error.ts
@@ -3,14 +3,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'viewlet.explorer-file-system-provider-error'
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
   await Workspace.setPath(tmpDir)
 
   // Mock file system provider to throw an error
-  await Command.execute('FileSystemProvider.setError', true)
+  await FileSystem.setProviderError(true)
 
   // act & assert - Try to expand directory when provider throws error
   await Explorer.focusIndex(0)
@@ -22,7 +22,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(errorMessage).toHaveText('File system provider error')
 
   // Reset error state
-  await Command.execute('FileSystemProvider.setError', false)
+  await FileSystem.setProviderError(false)
 
   // Should recover and work normally
   await Explorer.refresh()

--- a/packages/e2e/src/viewlet.explorer-file-system-provider-invalid-data.ts
+++ b/packages/e2e/src/viewlet.explorer-file-system-provider-invalid-data.ts
@@ -3,14 +3,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 export const name = 'viewlet.explorer-file-system-provider-invalid-data'
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
   await Workspace.setPath(tmpDir)
 
   // Mock file system provider to return invalid data (null/undefined entries)
-  await Command.execute('FileSystemProvider.setInvalidData', true)
+  await FileSystem.setProviderInvalidData(true)
 
   // act & assert - Try to expand directory when provider returns invalid data
   await Explorer.focusIndex(0)
@@ -28,7 +28,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(brokenItems).toHaveCount(0)
 
   // Reset to normal data
-  await Command.execute('FileSystemProvider.setInvalidData', false)
+  await FileSystem.setProviderInvalidData(false)
   await Explorer.refresh()
 
   // Should work normally after reset

--- a/packages/e2e/src/viewlet.explorer-files-exclude-reveal-descendant.ts
+++ b/packages/e2e/src/viewlet.explorer-files-exclude-reveal-descendant.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-files-exclude-reveal-descendant'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/project/.git`)
   await FileSystem.writeFile(`${tmpDir}/project/.git/config`, '')
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   const project = Locator('.TreeItem[aria-label="project"]')
   const config = Locator('.TreeItem[aria-label="config"]')
   const explorer = Locator('.Explorer')
-  await Command.execute('Explorer.reveal', `${tmpDir}/project/.git/config`)
+  await Explorer.reveal(`${tmpDir}/project/.git/config`)
 
   await expect(explorer).toBeVisible()
   await expect(config).toBeHidden()

--- a/packages/e2e/src/viewlet.explorer-files-exclude-reveal-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-files-exclude-reveal-folder.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-files-exclude-reveal-folder'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/.git`)
   await FileSystem.writeFile(`${tmpDir}/visible.txt`, '')
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   const visible = Locator('.TreeItem[aria-label="visible.txt"]')
   const gitFolder = Locator('.TreeItem[aria-label=".git"]')
   const explorer = Locator('.Explorer')
-  await Command.execute('Explorer.reveal', `${tmpDir}/.git`)
+  await Explorer.reveal(`${tmpDir}/.git`)
 
   await expect(explorer).toBeVisible()
   await expect(gitFolder).toBeHidden()

--- a/packages/e2e/src/viewlet.explorer-focus-last-empty-workspace-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-last-empty-workspace-no-op.ts
@@ -2,11 +2,11 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-last-empty-workspace-no-op'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await Workspace.setPath(tmpDir)
 
-  await Command.execute('Explorer.focusLast')
+  await Explorer.focusLast()
 
   const treeItems = Locator('.TreeItem')
   const activeItems = Locator('#TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-focus-next-without-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-next-without-focus.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-next-without-focus'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act
-  await Command.execute('Explorer.focusNext')
+  await Explorer.focusNext()
 
   // assert
   const firstFile = Locator('.TreeItem[aria-label="a.txt"]')

--- a/packages/e2e/src/viewlet.explorer-focus-none.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-none.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-none'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -11,12 +11,12 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // focus a file
-  await Command.execute('Explorer.focusIndex', 1)
+  await Explorer.focusIndex(1)
   const file2 = Locator('.TreeItem').nth(1)
   await expect(file2).toHaveId('TreeItemActive')
 
   // act
-  await Command.execute('Explorer.focusNone')
+  await Explorer.focusNone()
 
   // assert - no item should have the active id
   const activeItem = Locator('#TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-at-start.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-at-start.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-at-start'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusIndex(0)
 
   // act
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   // assert
   const firstFile = Locator('.TreeItem[aria-label="a.txt"]')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-empty-workspace-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-empty-workspace-no-op.ts
@@ -2,11 +2,11 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-empty-workspace-no-op'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await Workspace.setPath(tmpDir)
 
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   const treeItems = Locator('.TreeItem')
   const listItems = Locator('.ListItems')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-from-last.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-from-last.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-from-last'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(2)
 
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   const secondFile = Locator('.TreeItem[aria-label="b.txt"]')
   await expect(secondFile).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-from-middle.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-from-middle.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-from-middle'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(1)
 
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   const firstFile = Locator('.TreeItem[aria-label="a.txt"]')
   await expect(firstFile).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-next-across-viewport'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   for (let i = 0; i < 120; i++) {
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
 
   // act
   await Explorer.focusIndex(90)
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
   await Explorer.focusNext()
 
   // assert

--- a/packages/e2e/src/viewlet.explorer-focus-previous-single-item-no-op.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-single-item-no-op.ts
@@ -2,13 +2,13 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-single-item-no-op'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/only.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
 
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   const onlyFile = Locator('.TreeItem[aria-label="only.txt"]')
   const treeItems = Locator('.TreeItem')

--- a/packages/e2e/src/viewlet.explorer-focus-previous-without-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-without-focus.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-previous-without-focus'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act
-  await Command.execute('Explorer.focusPrevious')
+  await Explorer.focusPrevious()
 
   // assert
   const lastFile = Locator('.TreeItem[aria-label="b.txt"]')

--- a/packages/e2e/src/viewlet.explorer-handle-drop.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drop.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-handle-drop'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -15,7 +15,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   })
   const file = await fileHandle.getFile()
   const fileList = [file]
-  const id = await Command.execute('FileSystemHandle.addFileHandle', fileHandle)
+  const id = await FileSystem.registerFileHandle(fileHandle)
 
   // act
   await Explorer.handleDrop(0, 0, [id], fileList)

--- a/packages/e2e/src/viewlet.explorer-large-directory-typeahead-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-large-directory-typeahead-focus.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-large-directory-typeahead-focus'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
@@ -13,14 +13,14 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.focusFirst()
 
   // act
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Explorer.handleKeyDown(false, 'b')
 
   // assert
   const banana = Locator('.TreeItem[aria-label="banana.txt"]')
   await expect(banana).toHaveId('TreeItemActive')
 
   // act
-  await Command.execute('Explorer.handleKeyDown', false, 'e')
+  await Explorer.handleKeyDown(false, 'e')
 
   // assert
   const berry = Locator('.TreeItem[aria-label="berry.txt"]')

--- a/packages/e2e/src/viewlet.explorer-open-folder-enoent-error.ts
+++ b/packages/e2e/src/viewlet.explorer-open-folder-enoent-error.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-open-folder-enoent-error'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar, Workspace }) => {
+export const test: Test = async ({ expect, FileSystem, Layout, Locator, SideBar, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const missingFolder = `${tmpDir}/missing-folder`
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, SideBar
   await SideBar.hide()
 
   // act
-  await Command.execute('Layout.showSideBar')
+  await Layout.showSideBar()
 
   // assert
   const error = Locator('.Explorer .WelcomeMessage')

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-blur.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-blur'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
   // act: acceptEdit and handleInputBlur both try to accept the same edit concurrently
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.handleInputBlur')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.handleInputBlur()])
 
   // assert: explorer should be stable — no crash
   // The file should exist on disk (if created before or by acceptEdit)

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-cancel.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-cancel.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-cancel'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
   // act: acceptEdit creates the file, cancelEdit (escape) cancels — both fire concurrently
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.cancelEdit')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.cancelEdit()])
 
   // assert: explorer should be stable — no crash
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-accept-edit-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-edit-refresh.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-edit-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
   // act: acceptEdit creates the file on disk, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // The file should exist on disk (created by acceptEdit)

--- a/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-accept-rename-refresh.ts
@@ -2,18 +2,18 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-accept-rename-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, 'a')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, 'b')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
-  await Command.execute('Explorer.renameDirent')
-  await Command.execute('Explorer.updateEditingValue', 'renamed.txt')
+  await Explorer.focusIndex(0)
+  await Explorer.renameDirent()
+  await Explorer.updateEditingValue('renamed.txt')
 
   // act: acceptEdit renames the file while refresh concurrently reads the old directory state
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.refresh()])
 
   // assert: the accepted name is present on disk and represented once in the tree
   await FileSystem.shouldHaveFile(`${tmpDir}/renamed.txt`, 'a')

--- a/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-arrow-left-refresh.ts
@@ -2,18 +2,18 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-arrow-left-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, 'child')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.handleClick', 0)
-  await Command.execute('Explorer.focusIndex', 1)
+  await Explorer.handleClick(0)
+  await Explorer.focusIndex(1)
 
   // act: handleArrowLeft moves focus to the parent while refresh concurrently rebuilds the tree
-  await Promise.all([Command.execute('Explorer.handleArrowLeft'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleArrowLeft(), Explorer.refresh()])
 
   // assert: the tree has no stale or duplicate rows
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-race-arrow-right-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-arrow-right-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-arrow-right-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/f1.txt`, 'f1')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: handleArrowRight expands the focused folder, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleArrowRight'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleArrowRight(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate children
   // folder and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-blur-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-blur-refresh.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-blur-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
   // act: blur auto-accepts the edit (creates file), refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleInputBlur'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleInputBlur(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash
   // The file should exist on disk (created by blur auto-accept)

--- a/packages/e2e/src/viewlet.explorer-race-collapse-all-expand-one.ts
+++ b/packages/e2e/src/viewlet.explorer-race-collapse-all-expand-one.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-collapse-all-expand-one'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
@@ -10,10 +10,10 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await FileSystem.writeFile(`${tmpDir}/a/f1.txt`, 'f1')
   await FileSystem.writeFile(`${tmpDir}/b/f2.txt`, 'f2')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
+  await Explorer.expandRecursively()
 
   // act: collapseAll collapses the tree, handleClick on folder a expands it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.collapseAll'), Command.execute('Explorer.handleClick', 0)])
+  await Promise.all([Explorer.collapseAll(), Explorer.handleClick(0)])
 
   // assert: explorer should be stable — no crash, no orphaned children
   // folder a and folder b should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-collapse-all-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-collapse-all-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, 'child')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
+  await Explorer.expandRecursively()
 
   // act: collapseAll removes expanded children while refresh concurrently rebuilds the tree
-  await Promise.all([Command.execute('Explorer.collapseAll'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.collapseAll(), Explorer.refresh()])
 
   // assert: top-level items remain stable and no child is duplicated
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-copy-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-copy-refresh'
 
-export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: handleCopy captures the focused item while refresh concurrently replaces that item
-  await Promise.all([Command.execute('Explorer.handleCopy'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleCopy(), Explorer.refresh()])
 
   // assert: both files remain visible exactly once
   const file1 = Locator('.TreeItem[aria-label="file1.txt"]')

--- a/packages/e2e/src/viewlet.explorer-race-create-delete-same-name.ts
+++ b/packages/e2e/src/viewlet.explorer-race-create-delete-same-name.ts
@@ -4,18 +4,18 @@ export const name = 'viewlet.explorer-race-create-delete-same-name'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'file2.txt')
-  await Command.execute('Explorer.focusIndex', 1)
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('file2.txt')
+  await Explorer.focusIndex(1)
 
   // act: acceptEdit tries to create 'file2.txt' (which already exists), removeDirent deletes file2.txt — both fire concurrently
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-create-folder-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-create-folder-delete.ts
@@ -2,18 +2,18 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-create-folder-delete'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFolder')
-  await Command.execute('Explorer.updateEditingValue', 'new-folder')
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.newFolder()
+  await Explorer.updateEditingValue('new-folder')
+  await Explorer.focusIndex(0)
 
   // act: acceptEdit creates the folder, removeDirent deletes file1.txt — both fire concurrently
-  await Promise.all([Command.execute('Explorer.acceptEdit'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.acceptEdit(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash
   // file2.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-cut-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-cut-refresh.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-cut-refresh'
 
-export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -11,11 +11,11 @@ export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locat
   await FileSystem.writeFile(`${tmpDir}/a/f2.txt`, 'f2')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
-  await Command.execute('Explorer.focusIndex', 1)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
 
   // act: handleCut marks f1.txt with cut decoration, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleCut'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleCut(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale cut decorations
   // folder a and folder b should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-delete-file-new-file.ts
+++ b/packages/e2e/src/viewlet.explorer-race-delete-file-new-file.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-delete-file-new-file'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: removeDirent deletes the focused file, newFile inserts an editing item — both fire concurrently
-  await Promise.all([Command.execute('Explorer.removeDirent'), Command.execute('Explorer.newFile')])
+  await Promise.all([Explorer.removeDirent(), Explorer.newFile()])
 
   // assert: explorer should be stable — no crash, no stale rows
   // file2.txt and file3.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-delete-file-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-delete-file-refresh.ts
@@ -4,17 +4,17 @@ export const name = 'viewlet.explorer-race-delete-file-refresh'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: removeDirent deletes file1, refresh rebuilds tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.removeDirent'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.removeDirent(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale references
   // file2.txt and file3.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-double-click-blur.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-blur.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-blur'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
 
   // act: double-click on empty space creates input (with empty value),
   // handleInputBlur with empty value cancels — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDoubleClick', 20, 100), Command.execute('Explorer.handleInputBlur')])
+  await Promise.all([Explorer.handleDoubleClick(20, 100), Explorer.handleInputBlur()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-double-click-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-cancel-edit.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-cancel-edit'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act: handleDoubleClick creates editing row on empty space, cancelEdit cancels it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDoubleClick', 20, 100), Command.execute('Explorer.cancelEdit')])
+  await Promise.all([Explorer.handleDoubleClick(20, 100), Explorer.cancelEdit()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-double-click-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-delete.ts
@@ -4,15 +4,15 @@ export const name = 'viewlet.explorer-race-double-click-delete'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: handleDoubleClick on empty space creates editing row, removeDirent deletes file1.txt — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDoubleClick', 20, 100), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.handleDoubleClick(20, 100), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no stale references
   // At most 1 tree item (possibly editing row)

--- a/packages/e2e/src/viewlet.explorer-race-double-click-escape.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-escape.ts
@@ -4,14 +4,14 @@ export const name = 'viewlet.explorer-race-double-click-escape'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act: double-click on empty space creates a new file input, escape cancels it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDoubleClick', 20, 100), Command.execute('Explorer.handleEscape')])
+  await Promise.all([Explorer.handleDoubleClick(20, 100), Explorer.handleEscape()])
 
   // assert: explorer should be stable — either input is visible (double-click won) or hidden (escape won), but not both
   const items = Locator('.TreeItem')

--- a/packages/e2e/src/viewlet.explorer-race-double-click-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-double-click-refresh.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-double-click-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
 
   // act: double-click on empty space creates a new file input, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDoubleClick', 20, 100), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleDoubleClick(20, 100), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-drop-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-drop-refresh.ts
@@ -4,20 +4,20 @@ export const name = 'viewlet.explorer-race-drop-refresh'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
   await FileSystem.writeFile(`${tmpDir}/a/f1.txt`, 'f1')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
+  await Explorer.expandRecursively()
   // drag f1.txt over folder b
-  await Command.execute('Explorer.focusIndex', 1)
-  await Command.execute('Explorer.handleDragOverIndex', 2)
+  await Explorer.focusIndex(1)
+  await Explorer.handleDragOverIndex(2)
 
   // act: handleDrop drops the dragged file, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleDrop'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleDrop(0, 0, [], []), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // folder a and folder b should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-accept-edit'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
-  // act: cancelEdit cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.acceptEdit')])
+  // act: handleEscape cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
+  await Promise.all([Explorer.handleEscape(), Explorer.acceptEdit()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-accept-edit.ts
@@ -10,8 +10,8 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.newFile()
   await Explorer.updateEditingValue('created.txt')
 
-  // act: handleEscape cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
-  await Promise.all([Explorer.handleEscape(), Explorer.acceptEdit()])
+  // act: cancelEdit cancels the inline edit, acceptEdit tries to accept it — both fire concurrently
+  await Promise.all([Explorer.cancelEdit(), Explorer.acceptEdit()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
@@ -9,8 +9,8 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Workspace.setPath(tmpDir)
   await Explorer.newFile()
 
-  // act: handleEscape cancels the editing row, newFile tries to start a new one — both fire concurrently
-  await Promise.all([Explorer.handleEscape(), Explorer.newFile()])
+  // act: cancelEdit cancels the editing row, newFile tries to start a new one — both fire concurrently
+  await Promise.all([Explorer.cancelEdit(), Explorer.newFile()])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-new-file.ts
@@ -2,15 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-new-file'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
+  await Explorer.newFile()
 
-  // act: cancelEdit cancels the editing row, newFile tries to start a new one — both fire concurrently
-  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.newFile')])
+  // act: handleEscape cancels the editing row, newFile tries to start a new one — both fire concurrently
+  await Promise.all([Explorer.handleEscape(), Explorer.newFile()])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-escape-update-editing-value'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'draft.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('draft.txt')
 
-  // act: cancelEdit cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
-  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.updateEditingValue', 'other.txt')])
+  // act: handleEscape cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
+  await Promise.all([Explorer.handleEscape(), Explorer.updateEditingValue('other.txt')])
 
   // assert: explorer should be stable — no crash, no stale editing state
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
+++ b/packages/e2e/src/viewlet.explorer-race-escape-update-editing-value.ts
@@ -10,8 +10,8 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.newFile()
   await Explorer.updateEditingValue('draft.txt')
 
-  // act: handleEscape cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
-  await Promise.all([Explorer.handleEscape(), Explorer.updateEditingValue('other.txt')])
+  // act: cancelEdit cancels the edit, updateEditingValue tries to set a value on cancelled edit — both fire concurrently
+  await Promise.all([Explorer.cancelEdit(), Explorer.updateEditingValue('other.txt')])
 
   // assert: explorer should be stable — no crash, no stale editing state
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-all-refresh.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-all-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: expandAll reads both folders while refresh concurrently replaces their rows
-  await Promise.all([Command.execute('Explorer.expandAll'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.expandAll(), Explorer.refresh()])
 
   // assert: root folders remain visible and neither child is duplicated
   const a = Locator('.TreeItem[aria-label="a"]')

--- a/packages/e2e/src/viewlet.explorer-race-expand-delete-child.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-delete-child.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-race-expand-delete-child'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
@@ -13,11 +13,11 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
   // focus f1.txt (index 1 after expand)
-  await Command.execute('Explorer.expandRecursively')
-  await Command.execute('Explorer.focusIndex', 1)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
 
   // act: handleClick on folder a toggles expand/collapse, removeDirent deletes f1.txt — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleClick', 0), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.handleClick(0), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no stale rows
   // folder a and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-folder-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-folder-refresh.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-folder-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: click folder to expand (async reads children), refresh rebuilds tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handleClick', 0), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handleClick(0), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate children
   // folder and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursive-click-child.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursive-click-child.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursive-click-child'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b/c`)
   await FileSystem.writeFile(`${tmpDir}/a/b/c/d.txt`, 'd')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: expandRecursively unfolds the entire tree, handleClick on folder a toggles expand — both fire concurrently
-  await Promise.all([Command.execute('Explorer.expandRecursively'), Command.execute('Explorer.handleClick', 0)])
+  await Promise.all([Explorer.expandRecursively(), Explorer.handleClick(0)])
 
   // assert: explorer should be stable — no crash, no orphaned children
   // a and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursive-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursive-delete.ts
@@ -4,17 +4,17 @@ export const name = 'viewlet.explorer-race-expand-recursive-delete'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b/c`)
   await FileSystem.writeFile(`${tmpDir}/a/b/c/d.txt`, 'd')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: expandRecursively unfolds the tree, removeDirent deletes folder a — both fire concurrently
-  await Promise.all([Command.execute('Explorer.expandRecursively'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.expandRecursively(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no orphaned children without parent
   // root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursively-collapse-all.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursively-collapse-all.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursively-collapse-all'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b/c`)
   await FileSystem.writeFile(`${tmpDir}/a/b/c/d.txt`, 'd')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: expandRecursively unfolds the tree, collapseAll collapses it — both fire concurrently
-  await Promise.all([Command.execute('Explorer.expandRecursively'), Command.execute('Explorer.collapseAll')])
+  await Promise.all([Explorer.expandRecursively(), Explorer.collapseAll()])
 
   // assert: explorer should be stable — no crash, no orphaned children without parent
   // a (folder) and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-recursively-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-recursively-refresh.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-recursively-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a/b/c`)
@@ -11,10 +11,10 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await FileSystem.mkdir(`${tmpDir}/folder-2`)
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: expandRecursively reads children recursively, refresh rebuilds tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.expandRecursively'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.expandRecursively(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // root folder items should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-expand-two-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-race-expand-two-folders.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-expand-two-folders'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder-a`)
@@ -14,7 +14,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: click both folders concurrently to expand them — async expansions race
-  await Promise.all([Command.execute('Explorer.handleClick', 0), Command.execute('Explorer.handleClick', 1)])
+  await Promise.all([Explorer.handleClick(0), Explorer.handleClick(1)])
 
   // assert: explorer should be stable — no crash, no children from A under B or vice versa
   // Both folders should be visible

--- a/packages/e2e/src/viewlet.explorer-race-focus-index-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-index-delete.ts
@@ -4,17 +4,17 @@ export const name = 'viewlet.explorer-race-focus-index-delete'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: focusIndex changes focus to index 1, removeDirent deletes currently focused item (0) — both fire concurrently
-  await Promise.all([Command.execute('Explorer.focusIndex', 1), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.focusIndex(1), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no stale focus
   // file2.txt and file3.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-focus-next-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-next-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-focus-next-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: focusNext moves focus to next item, refresh rebuilds tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.focusNext'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.focusNext(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale focus
   // All files should be visible

--- a/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-focus-previous-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-focus-previous-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 2)
+  await Explorer.focusIndex(2)
 
   // act: focusPrevious changes the active row while refresh concurrently replaces all rows
-  await Promise.all([Command.execute('Explorer.focusPrevious'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.focusPrevious(), Explorer.refresh()])
 
   // assert: all files remain visible exactly once
   const file1 = Locator('.TreeItem[aria-label="file1.txt"]')

--- a/packages/e2e/src/viewlet.explorer-race-new-file-accept-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-accept-edit.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-accept-edit'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'created.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('created.txt')
 
   // act: newFile is no-op (already editing), acceptEdit creates the file — both fire concurrently
-  await Promise.all([Command.execute('Explorer.newFile'), Command.execute('Explorer.acceptEdit')])
+  await Promise.all([Explorer.newFile(), Explorer.acceptEdit()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-new-file-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-cancel-edit.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-cancel-edit'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'draft.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('draft.txt')
 
   // act: cancelEdit cancels the current edit, newFile starts a new one — both fire concurrently
-  await Promise.all([Command.execute('Explorer.cancelEdit'), Command.execute('Explorer.newFile')])
+  await Promise.all([Explorer.cancelEdit(), Explorer.newFile()])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-new-file-focus-none.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-focus-none.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-focus-none'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: newFile creates editing row, focusNone clears all focus — both fire concurrently
-  await Promise.all([Command.execute('Explorer.newFile'), Command.execute('Explorer.focusNone')])
+  await Promise.all([Explorer.newFile(), Explorer.focusNone()])
 
   // assert: explorer should be stable — no crash, no stale focus
   // file1.txt and file2.txt should be visible

--- a/packages/e2e/src/viewlet.explorer-race-new-file-refresh-while-editing.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-refresh-while-editing.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-refresh-while-editing'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.newFile')
-  await Command.execute('Explorer.updateEditingValue', 'draft.txt')
+  await Explorer.newFile()
+  await Explorer.updateEditingValue('draft.txt')
 
   // act: newFile should be a no-op (editingIndex !== -1), refresh rebuilds — both fire concurrently
-  await Promise.all([Command.execute('Explorer.newFile'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.newFile(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // file1.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-new-file-switch-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-switch-folders.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-switch-folders'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
@@ -11,9 +11,9 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: focus folder a then folder b, then fire two concurrent newFile calls
-  await Command.execute('Explorer.focusIndex', 0)
-  await Command.execute('Explorer.focusIndex', 1)
-  await Promise.all([Command.execute('Explorer.newFile'), Command.execute('Explorer.newFile')])
+  await Explorer.focusIndex(0)
+  await Explorer.focusIndex(1)
+  await Promise.all([Explorer.newFile(), Explorer.newFile()])
 
   // assert: only one input should be visible — both calls should not produce two inputs
   const inputBoxes = Locator('input')

--- a/packages/e2e/src/viewlet.explorer-race-new-file-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-file-twice.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-file-twice'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: two concurrent newFile calls — the editingIndex guard should prevent a duplicate
-  await Promise.all([Command.execute('Explorer.newFile'), Command.execute('Explorer.newFile')])
+  await Promise.all([Explorer.newFile(), Explorer.newFile()])
 
   // assert: only one editing input should exist — 3 files + 1 editing row = 4 tree items
   const treeItems = Locator('.TreeItem')

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-cancel-edit.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-folder-cancel-edit'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: newFolder inserts an editing row while cancelEdit concurrently tries to remove it
-  await Promise.all([Command.execute('Explorer.newFolder'), Command.execute('Explorer.cancelEdit')])
+  await Promise.all([Explorer.newFolder(), Explorer.cancelEdit()])
 
   // assert: existing rows remain stable and at most one editing row survives
   const file1 = Locator('.TreeItem[aria-label="file1.txt"]')

--- a/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-new-folder-twice.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-new-folder-twice'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: two newFolder commands concurrently try to insert an editing row
-  await Promise.all([Command.execute('Explorer.newFolder'), Command.execute('Explorer.newFolder')])
+  await Promise.all([Explorer.newFolder(), Explorer.newFolder()])
 
   // assert: the editing guard permits only one row and one input
   const treeItems = Locator('.TreeItem')

--- a/packages/e2e/src/viewlet.explorer-race-paste-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-paste-delete.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-race-paste-delete'
 
 export const skip = 1
 
-export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -13,14 +13,14 @@ export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locat
   await FileSystem.writeFile(`${tmpDir}/a/f2.txt`, 'f2')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
-  await Command.execute('Explorer.focusIndex', 1)
-  await Command.execute('Explorer.handleCopy')
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
+  await Explorer.handleCopy()
   // focus folder b (index 3 after expand: a[0], f1[1], f2[2], b[3])
-  await Command.execute('Explorer.focusIndex', 3)
+  await Explorer.focusIndex(3)
 
   // act: handlePaste pastes into folder b, removeDirent deletes folder b — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handlePaste'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.handlePaste(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no orphaned pasted items
   // folder a should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-paste-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-paste-refresh.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-race-paste-refresh'
 
 export const skip = 1
 
-export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -13,13 +13,13 @@ export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locat
   await FileSystem.writeFile(`${tmpDir}/a/f2.txt`, 'f2')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
-  await Command.execute('Explorer.focusIndex', 1)
-  await Command.execute('Explorer.handleCopy')
-  await Command.execute('Explorer.focusIndex', 3)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
+  await Explorer.handleCopy()
+  await Explorer.focusIndex(3)
 
   // act: handlePaste pastes the copied file into folder b, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.handlePaste'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.handlePaste(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // folder a and folder b should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-paste-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-paste-twice.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-race-paste-twice'
 
 export const skip = 1
 
-export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -12,13 +12,13 @@ export const test: Test = async ({ ClipBoard, Command, expect, FileSystem, Locat
   await FileSystem.writeFile(`${tmpDir}/a/file.txt`, 'content')
   await FileSystem.mkdir(`${tmpDir}/b`)
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.expandRecursively')
-  await Command.execute('Explorer.focusIndex', 1)
-  await Command.execute('Explorer.handleCopy')
-  await Command.execute('Explorer.focusIndex', 2)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
+  await Explorer.handleCopy()
+  await Explorer.focusIndex(2)
 
   // act: two paste commands concurrently copy the same source into the same target
-  await Promise.all([Command.execute('Explorer.handlePaste'), Command.execute('Explorer.handlePaste')])
+  await Promise.all([Explorer.handlePaste(), Explorer.handlePaste()])
 
   // assert: source and target remain stable without duplicate tree rows for one URI
   const a = Locator('.TreeItem[aria-label="a"]')

--- a/packages/e2e/src/viewlet.explorer-race-refresh-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-refresh-twice.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-refresh-twice'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: two concurrent refresh calls — both rebuild the tree
-  await Promise.all([Command.execute('Explorer.refresh'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.refresh(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no duplicate items
   // All files should be visible

--- a/packages/e2e/src/viewlet.explorer-race-rename-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-delete.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-delete'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, 'a')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, 'b')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: renameDirent starts inline rename on a.txt, removeDirent deletes a.txt — both fire concurrently
-  await Promise.all([Command.execute('Explorer.renameDirent'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.renameDirent(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no stale references to deleted item
   // b.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-rename-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-refresh.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, 'a')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, 'b')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: renameDirent starts inline rename, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.renameDirent'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.renameDirent(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale rows
   // a.txt and b.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-rename-twice.ts
+++ b/packages/e2e/src/viewlet.explorer-race-rename-twice.ts
@@ -2,16 +2,16 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-rename-twice'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, 'a')
   await FileSystem.writeFile(`${tmpDir}/b.txt`, 'b')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: two concurrent renameDirent calls on the same focused item
-  await Promise.all([Command.execute('Explorer.renameDirent'), Command.execute('Explorer.renameDirent')])
+  await Promise.all([Explorer.renameDirent(), Explorer.renameDirent()])
 
   // assert: explorer should be stable — no crash, no duplicate inputs
   // a.txt and b.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-restore-state-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-restore-state-refresh.ts
@@ -2,18 +2,18 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-restore-state-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/f1.txt`, 'f1')
   await FileSystem.writeFile(`${tmpDir}/root.txt`, 'root')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.handleClick', 0)
-  await Command.execute('Explorer.saveState')
+  await Explorer.handleClick(0)
+  await Explorer.saveState()
 
   // act: restoreState restores saved expand/scroll state, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.restoreState'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.restoreState(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no corrupt state
   // folder and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-save-state-expand.ts
+++ b/packages/e2e/src/viewlet.explorer-race-save-state-expand.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-save-state-expand'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspa
   await Workspace.setPath(tmpDir)
 
   // act: saveState saves scroll/expand state, handleClick expands folder — both fire concurrently
-  await Promise.all([Command.execute('Explorer.saveState'), Command.execute('Explorer.handleClick', 0)])
+  await Promise.all([Explorer.saveState(), Explorer.handleClick(0)])
 
   // assert: explorer should be stable — no crash, no stale state
   // folder and root.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-select-all-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-all-delete.ts
@@ -4,17 +4,17 @@ export const name = 'viewlet.explorer-race-select-all-delete'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: selectAll selects all items, removeDirent deletes the focused item — both fire concurrently
-  await Promise.all([Command.execute('Explorer.selectAll'), Command.execute('Explorer.removeDirent')])
+  await Promise.all([Explorer.selectAll(), Explorer.removeDirent()])
 
   // assert: explorer should be stable — no crash, no stale selection references
   // file2.txt and file3.txt should always be visible

--- a/packages/e2e/src/viewlet.explorer-race-select-down-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-down-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-select-down-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: selectDown extends selection downward, refresh rebuilds the tree — both fire concurrently
-  await Promise.all([Command.execute('Explorer.selectDown'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.selectDown(), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale selection
   // All files should be visible

--- a/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-select-up-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-select-up-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 2)
+  await Explorer.focusIndex(2)
 
   // act: selectUp extends selection while refresh concurrently replaces the selected rows
-  await Promise.all([Command.execute('Explorer.selectUp'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.selectUp(), Explorer.refresh()])
 
   // assert: all files remain visible exactly once
   const file1 = Locator('.TreeItem[aria-label="file1.txt"]')

--- a/packages/e2e/src/viewlet.explorer-race-toggle-selection-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-race-toggle-selection-refresh.ts
@@ -2,17 +2,17 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-race-toggle-selection-refresh'
 
-export const test: Test = async ({ Command, expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
   await FileSystem.writeFile(`${tmpDir}/file2.txt`, 'content 2')
   await FileSystem.writeFile(`${tmpDir}/file3.txt`, 'content 3')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.focusIndex', 0)
+  await Explorer.focusIndex(0)
 
   // act: toggleIndividualSelection toggles multi-select for focused item, refresh rebuilds — both fire concurrently
-  await Promise.all([Command.execute('Explorer.toggleIndividualSelection'), Command.execute('Explorer.refresh')])
+  await Promise.all([Explorer.toggleIndividualSelection(0), Explorer.refresh()])
 
   // assert: explorer should be stable — no crash, no stale selection
   // All files should be visible

--- a/packages/e2e/src/viewlet.explorer-read-folder-error-recovers-after-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-read-folder-error-recovers-after-refresh.ts
@@ -4,13 +4,13 @@ export const name = 'viewlet.explorer-read-folder-error-recovers-after-refresh'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
   await Workspace.setPath(tmpDir)
-  await Command.execute('FileSystemProvider.setError', true)
+  await FileSystem.setProviderError(true)
 
   // act
   await Explorer.focusFirst()
@@ -21,7 +21,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(error).toBeVisible()
 
   // act
-  await Command.execute('FileSystemProvider.setError', false)
+  await FileSystem.setProviderError(false)
   await Explorer.refresh()
   await Explorer.expandRecursively()
 

--- a/packages/e2e/src/viewlet.explorer-refresh-external-move-between-expanded-folders.ts
+++ b/packages/e2e/src/viewlet.explorer-refresh-external-move-between-expanded-folders.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-refresh-external-move-between-expanded-folders'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/a`)
@@ -12,7 +12,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.expandRecursively()
 
   // act
-  await Command.execute('FileSystem.rename', `${tmpDir}/a/file.txt`, `${tmpDir}/b/file.txt`)
+  await FileSystem.rename(`${tmpDir}/a/file.txt`, `${tmpDir}/b/file.txt`)
   await Explorer.refresh()
 
   // assert

--- a/packages/e2e/src/viewlet.explorer-refresh-external-rename-expanded-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-refresh-external-rename-expanded-folder.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-refresh-external-rename-expanded-folder'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/before`)
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.expandRecursively()
 
   // act
-  await Command.execute('FileSystem.rename', `${tmpDir}/before`, `${tmpDir}/after`)
+  await FileSystem.rename(`${tmpDir}/before`, `${tmpDir}/after`)
   await Explorer.refresh()
 
   // assert

--- a/packages/e2e/src/viewlet.explorer-restore-expanded-folders-after-reload.ts
+++ b/packages/e2e/src/viewlet.explorer-restore-expanded-folders-after-reload.ts
@@ -4,19 +4,19 @@ export const name = 'viewlet.explorer-restore-expanded-folders-after-reload'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.expandRecursively()
-  const savedState = await Command.execute('Explorer.saveState')
+  const savedState = await Explorer.saveState()
 
   // act
   await Workspace.setPath('')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.restoreState', savedState)
+  await Explorer.restoreState(savedState)
 
   // assert
   const folder = Locator('.TreeItem[aria-label="folder"]')

--- a/packages/e2e/src/viewlet.explorer-restore-focus-existing-or-fallback-deleted.ts
+++ b/packages/e2e/src/viewlet.explorer-restore-focus-existing-or-fallback-deleted.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-restore-focus-existing-or-fallback-deleted'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/a.txt`, '')
@@ -10,13 +10,13 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await FileSystem.writeFile(`${tmpDir}/c.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(1)
-  const savedState = await Command.execute('Explorer.saveState')
+  const savedState = await Explorer.saveState()
 
   // act
   await FileSystem.remove(`${tmpDir}/b.txt`)
   await Workspace.setPath('')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.restoreState', savedState)
+  await Explorer.restoreState(savedState)
 
   // assert
   const deleted = Locator('.TreeItem[aria-label="b.txt"]')

--- a/packages/e2e/src/viewlet.explorer-restore-scroll-position-long-list.ts
+++ b/packages/e2e/src/viewlet.explorer-restore-scroll-position-long-list.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-restore-scroll-position-long-list'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   for (let i = 0; i < 200; i++) {
@@ -12,12 +12,12 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   }
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(150)
-  const savedState = await Command.execute('Explorer.saveState')
+  const savedState = await Explorer.saveState()
 
   // act
   await Workspace.setPath('')
   await Workspace.setPath(tmpDir)
-  await Command.execute('Explorer.restoreState', savedState)
+  await Explorer.restoreState(savedState)
 
   // assert
   const restoredFile = Locator('.TreeItem[aria-label="file-150.txt"]')

--- a/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-collapsed-folder-preserves-order.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-reveal-collapsed-folder-preserves-order'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const nestedFilePath = `${tmpDir}/a/b/c.txt`
@@ -20,7 +20,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(nestedFile).toBeHidden()
 
   // act
-  await Command.execute('Explorer.reveal', nestedFilePath)
+  await Explorer.reveal(nestedFilePath)
 
   // assert
   await expect(nestedFile).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-reveal-from-tab-context-menu.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-from-tab-context-menu.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-reveal-from-tab-context-menu'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, ContextMenu, expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
+export const test: Test = async ({ ContextMenu, expect, Explorer, FileSystem, Locator, Main, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const firstFile = `${tmpDir}/a.txt`
@@ -26,7 +26,7 @@ export const test: Test = async ({ Command, ContextMenu, expect, Explorer, FileS
   await expect(tab).toBeVisible()
 
   // act
-  await Command.execute('Main.handleTabContextMenu', 0, 0, 0)
+  await Main.handleTabContextMenu(0, 0, 0)
   const closeMenuItem = Locator('text=Close').first()
   await expect(closeMenuItem).toBeVisible()
   await ContextMenu.selectItem('Reveal in Explorer')

--- a/packages/e2e/src/viewlet.explorer-reveal-nested-file-collapsed.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-nested-file-collapsed.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-reveal-nested-file-collapsed'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const nestedFilePath = `${tmpDir}/a/b/c.txt`
@@ -17,7 +17,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(nestedFile).toBeHidden()
 
   // act
-  await Command.execute('Explorer.reveal', nestedFilePath)
+  await Explorer.reveal(nestedFilePath)
 
   // assert
   await expect(nestedFile).toBeVisible()

--- a/packages/e2e/src/viewlet.explorer-reveal-non-existent-uri.ts
+++ b/packages/e2e/src/viewlet.explorer-reveal-non-existent-uri.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-reveal-non-existent-uri'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/first.txt`, '')
@@ -19,7 +19,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await expect(firstFile).toHaveId('TreeItemActive')
 
   // act
-  await Command.execute('Explorer.reveal', 'non-existent:///some-file.txt')
+  await Explorer.reveal('non-existent:///some-file.txt')
 
   // assert
   await expect(explorer).toBeVisible()

--- a/packages/e2e/src/viewlet.explorer-source-control-decoration-updates-after-create-rename-delete.ts
+++ b/packages/e2e/src/viewlet.explorer-source-control-decoration-updates-after-create-rename-delete.ts
@@ -4,7 +4,7 @@ export const name = 'viewlet.explorer-source-control-decoration-updates-after-cr
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, Extension, FileSystem, Locator, Settings, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, Extension, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({
     'explorer.sourceControlDecorations': true,
@@ -20,7 +20,7 @@ export const test: Test = async ({ Command, expect, Explorer, Extension, FileSys
   await Explorer.newFile()
   await Explorer.updateEditingValue('ignored.txt')
   await Explorer.acceptEdit()
-  await Command.execute('FileSystem.rename', `${tmpDir}/ignored.txt`, `${tmpDir}/ignored-renamed.txt`)
+  await FileSystem.rename(`${tmpDir}/ignored.txt`, `${tmpDir}/ignored-renamed.txt`)
   await FileSystem.remove(`${tmpDir}/tracked.txt`)
   await Explorer.refresh()
 

--- a/packages/e2e/src/viewlet.explorer-symlink-broken-displays-error.ts
+++ b/packages/e2e/src/viewlet.explorer-symlink-broken-displays-error.ts
@@ -4,10 +4,10 @@ export const name = 'viewlet.explorer-symlink-broken-displays-error'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  await Command.execute('FileSystem.symlink', `${tmpDir}/missing.txt`, `${tmpDir}/broken.txt`)
+  await FileSystem.symlink(`${tmpDir}/missing.txt`, `${tmpDir}/broken.txt`)
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-symlink-file-open.ts
+++ b/packages/e2e/src/viewlet.explorer-symlink-file-open.ts
@@ -4,11 +4,11 @@ export const name = 'viewlet.explorer-symlink-file-open'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/target.txt`, 'target content')
-  await Command.execute('FileSystem.symlink', `${tmpDir}/target.txt`, `${tmpDir}/link.txt`)
+  await FileSystem.symlink(`${tmpDir}/target.txt`, `${tmpDir}/link.txt`)
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-symlink-folder-expand-collapse.ts
+++ b/packages/e2e/src/viewlet.explorer-symlink-folder-expand-collapse.ts
@@ -4,12 +4,12 @@ export const name = 'viewlet.explorer-symlink-folder-expand-collapse'
 
 export const skip = 1
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/real-folder`)
   await FileSystem.writeFile(`${tmpDir}/real-folder/file.txt`, '')
-  await Command.execute('FileSystem.symlink', `${tmpDir}/real-folder`, `${tmpDir}/linked-folder`)
+  await FileSystem.symlink(`${tmpDir}/real-folder`, `${tmpDir}/linked-folder`)
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-typeahead-cycle-after-reset.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-cycle-after-reset.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-cycle-after-reset'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/banana.txt`, '')
@@ -10,12 +10,12 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Explorer.handleKeyDown(false, 'b')
   const banana = Locator('.TreeItem[aria-label="banana.txt"]')
   await expect(banana).toHaveId('TreeItemActive')
 
-  await Command.execute('Explorer.handleKeyDown', false, '')
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Explorer.handleKeyDown(false, '')
+  await Explorer.handleKeyDown(false, 'b')
 
   const berry = Locator('.TreeItem[aria-label="berry.txt"]')
   await expect(berry).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-default-prevented.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-default-prevented.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-default-prevented'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', true, 'b')
+  await Explorer.handleKeyDown(true, 'b')
 
   const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
   await expect(alpha).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-folder-prefix.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-folder-prefix.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-folder-prefix'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/alpha`)
   await FileSystem.mkdir(`${tmpDir}/beta`)
@@ -10,7 +10,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusLast()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
+  await Explorer.handleKeyDown(false, 'b')
 
   const beta = Locator('.TreeItem[aria-label="beta"]')
   await expect(beta).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-multiple-character-prefix.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-multiple-character-prefix.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-multiple-character-prefix'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/banana.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/berry.txt`, '')
@@ -10,8 +10,8 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
-  await Command.execute('Explorer.handleKeyDown', false, 'r')
+  await Explorer.handleKeyDown(false, 'b')
+  await Explorer.handleKeyDown(false, 'r')
 
   const brick = Locator('.TreeItem[aria-label="brick.txt"]')
   await expect(brick).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-nested-child.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-nested-child.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-nested-child'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/folder`)
   await FileSystem.writeFile(`${tmpDir}/folder/child.txt`, '')
@@ -11,7 +11,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Explorer.expandRecursively()
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'c')
+  await Explorer.handleKeyDown(false, 'c')
 
   const child = Locator('.TreeItem[aria-label="child.txt"]')
   await expect(child).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-no-match-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-no-match-keeps-focus.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-no-match-keeps-focus'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(1)
 
-  await Command.execute('Explorer.handleKeyDown', false, 'z')
+  await Explorer.handleKeyDown(false, 'z')
 
   const beta = Locator('.TreeItem[aria-label="beta.txt"]')
   await expect(beta).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-non-ascii-ignored.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-non-ascii-ignored.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-non-ascii-ignored'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/éclair.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'é')
+  await Explorer.handleKeyDown(false, 'é')
 
   const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
   await expect(alpha).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-reset-word.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-reset-word.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-reset-word'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
@@ -10,9 +10,9 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'b')
-  await Command.execute('Explorer.handleKeyDown', false, '')
-  await Command.execute('Explorer.handleKeyDown', false, 'c')
+  await Explorer.handleKeyDown(false, 'b')
+  await Explorer.handleKeyDown(false, '')
+  await Explorer.handleKeyDown(false, 'c')
 
   const charlie = Locator('.TreeItem[aria-label="charlie.txt"]')
   await expect(charlie).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-substring-does-not-match.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-substring-does-not-match.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-substring-does-not-match'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/snap.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(1)
 
-  await Command.execute('Explorer.handleKeyDown', false, 'a')
+  await Explorer.handleKeyDown(false, 'a')
 
   const alpha = Locator('.TreeItem[aria-label="alpha.txt"]')
   await expect(alpha).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-typeahead-uppercase.ts
+++ b/packages/e2e/src/viewlet.explorer-typeahead-uppercase.ts
@@ -2,14 +2,14 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-typeahead-uppercase'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/alpha.txt`, '')
   await FileSystem.writeFile(`${tmpDir}/beta.txt`, '')
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 
-  await Command.execute('Explorer.handleKeyDown', false, 'B')
+  await Explorer.handleKeyDown(false, 'B')
 
   const beta = Locator('.TreeItem[aria-label="beta.txt"]')
   await expect(beta).toHaveId('TreeItemActive')

--- a/packages/e2e/src/viewlet.explorer-welcome-open-folder-button.ts
+++ b/packages/e2e/src/viewlet.explorer-welcome-open-folder-button.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-welcome-open-folder-button'
 
-export const test: Test = async ({ Command, expect, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, Locator, Workspace }) => {
   // arrange
   await Workspace.setPath('')
 
@@ -12,5 +12,5 @@ export const test: Test = async ({ Command, expect, Locator, Workspace }) => {
   await expect(openFolderButton).toHaveText('Open folder')
 
   // act
-  await Command.execute('Explorer.handleClickOpenFolder')
+  await Explorer.handleClickOpenFolder()
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.92.0"
+    "@lvce-editor/server": "0.93.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"


### PR DESCRIPTION
Replaces explorer e2e Command.execute calls with typed Explorer, FileSystem, Layout, and Main test APIs. Updates the test-worker lock entry to v17.5.0.