### PR TITLE
Allow expanded explorer e2e suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -62,7 +62,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless -- --timeout=900000
+        run: npm run e2e:firefox:headless -- --timeout=1200000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-15, windows-2025]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -52,7 +52,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless -- --timeout=900000
+        run: npm run e2e:firefox:headless -- --timeout=1200000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure


### PR DESCRIPTION
Extends the three-platform CI job budget and Firefox page timeout so the expanded Explorer e2e suite can complete on the slower Windows runner.