### PR TITLE
feature: speed up explorer e2e fixtures

### DIFF
--- a/packages/e2e/src/viewlet.explorer-drag-autoscroll-long-list.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-autoscroll-long-list.ts
@@ -6,9 +6,12 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/target`)
-  for (let i = 0; i < 80; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(2, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 80 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   const opfsRoot = await navigator.storage.getDirectory()
   const fileHandle = await opfsRoot.getFileHandle('file-79.txt', { create: true })

--- a/packages/e2e/src/viewlet.explorer-expand-folder-100-items.ts
+++ b/packages/e2e/src/viewlet.explorer-expand-folder-100-items.ts
@@ -6,10 +6,12 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.mkdir(`${tmpDir}/stress-folder`)
-  for (let index = 0; index < 100; index++) {
-    const fileName = `item-${index.toString().padStart(5, '0')}.txt`
-    await FileSystem.writeFile(`${tmpDir}/stress-folder/${fileName}`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 100 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/stress-folder/item-${index.toString().padStart(5, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-expand-folder-preserves-item-indent.ts
+++ b/packages/e2e/src/viewlet.explorer-expand-folder-preserves-item-indent.ts
@@ -9,9 +9,12 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await FileSystem.mkdir(`${tmpDir}/packages/extension/src/parts/GetErrorMessage`)
   await FileSystem.mkdir(`${tmpDir}/packages/extension/src/parts/GithubClient/HelperBotClient`)
   await FileSystem.writeFile(`${tmpDir}/packages/extension/src/parts/GithubClient/GithubClient.ts`, '')
-  for (let index = 0; index < 50; index++) {
-    await FileSystem.writeFile(`${tmpDir}/root-${index.toString().padStart(2, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 50 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/root-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   await Explorer.focusFirst()
 

--- a/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-previous-next-across-viewport.ts
@@ -5,9 +5,12 @@ export const name = 'viewlet.explorer-focus-previous-next-across-viewport'
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 120; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 120 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(3, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-new-file-in-expanded-folder-scrolls-into-view.ts
+++ b/packages/e2e/src/viewlet.explorer-new-file-in-expanded-folder-scrolls-into-view.ts
@@ -5,9 +5,12 @@ export const name = 'viewlet.explorer-new-file-in-expanded-folder-scrolls-into-v
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 40; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(2, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 40 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
   await FileSystem.mkdir(`${tmpDir}/target-folder`)
   await FileSystem.writeFile(`${tmpDir}/target-folder/existing.txt`, '')
   await Workspace.setPath(tmpDir)

--- a/packages/e2e/src/viewlet.explorer-range-select-across-scroll-boundary.ts
+++ b/packages/e2e/src/viewlet.explorer-range-select-across-scroll-boundary.ts
@@ -7,9 +7,12 @@ export const skip = 1
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 120; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 120 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(3, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(5)
 

--- a/packages/e2e/src/viewlet.explorer-restore-scroll-position-long-list.ts
+++ b/packages/e2e/src/viewlet.explorer-restore-scroll-position-long-list.ts
@@ -7,9 +7,12 @@ export const skip = 1
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 200; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 200 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(3, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(150)
   const savedState = await Explorer.saveState()

--- a/packages/e2e/src/viewlet.explorer-scroll.ts
+++ b/packages/e2e/src/viewlet.explorer-scroll.ts
@@ -5,10 +5,12 @@ export const name = 'viewlet.explorer-scroll'
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 100; i++) {
-    const fileName = `file-${i.toString().padStart(2, '0')}.txt`
-    await FileSystem.writeFile(`${tmpDir}/${fileName}`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 100 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   const file00 = Locator('.TreeItem', { hasText: 'file-00.txt' })
   const file23 = Locator('.TreeItem', { hasText: 'file-23.txt' })

--- a/packages/e2e/src/viewlet.explorer-select-all-large-directory-delete-no-stale-rows.ts
+++ b/packages/e2e/src/viewlet.explorer-select-all-large-directory-delete-no-stale-rows.ts
@@ -8,9 +8,12 @@ export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator
   // arrange
   await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 500; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 500 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(3, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-select-all-then-delete-files.ts
+++ b/packages/e2e/src/viewlet.explorer-select-all-then-delete-files.ts
@@ -6,9 +6,12 @@ export const test: Test = async ({ Dialog, expect, Explorer, FileSystem, Locator
   // arrange
   await Dialog.mockConfirm(() => true)
   const tmpDir = await FileSystem.getTmpDir()
-  for (let index = 0; index < 10; index++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${index}.txt`, `content ${index}`)
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 10 }, (_, index) => ({
+      content: `content ${index}`,
+      uri: `${tmpDir}/file-${index}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(9)
 

--- a/packages/e2e/src/viewlet.explorer-set-delta-y-invalid-value.ts
+++ b/packages/e2e/src/viewlet.explorer-set-delta-y-invalid-value.ts
@@ -5,10 +5,12 @@ export const name = 'viewlet.explorer-set-delta-y-invalid-value'
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 30; i++) {
-    const fileName = `file-${i.toString().padStart(2, '0')}.txt`
-    await FileSystem.writeFile(`${tmpDir}/${fileName}`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 30 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   const file00 = Locator('.TreeItem', { hasText: 'file-00.txt' })
 

--- a/packages/e2e/src/viewlet.explorer-shift-range-after-scroll-and-refresh.ts
+++ b/packages/e2e/src/viewlet.explorer-shift-range-after-scroll-and-refresh.ts
@@ -5,9 +5,12 @@ export const name = 'viewlet.explorer-shift-range-after-scroll-and-refresh'
 export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  for (let i = 0; i < 120; i++) {
-    await FileSystem.writeFile(`${tmpDir}/file-${i.toString().padStart(3, '0')}.txt`, '')
-  }
+  await FileSystem.writeFiles(
+    Array.from({ length: 120 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(3, '0')}.txt`,
+    })),
+  )
   await Workspace.setPath(tmpDir)
   await Explorer.selectIndices([10, 11, 12, 13, 14, 15])
   await Explorer.focusIndex(90)


### PR DESCRIPTION
## Summary

- replace sequential fixture file creation with the FileSystem.writeFiles helper
- cover the fixture-heavy scrolling, selection, drag, and folder expansion tests
- preserve the existing benchmark tests and render flow

Related renderer reset/frame scheduling optimization: lvce-editor/lvce-editor#12883