### PR TITLE
fix: constrain explorer scrollbar thumb

### DIFF
--- a/packages/explorer-view/src/parts/GetScrollBarTop/GetScrollBarTop.ts
+++ b/packages/explorer-view/src/parts/GetScrollBarTop/GetScrollBarTop.ts
@@ -1,8 +1,9 @@
-export const getScrollBarTop = (height: number, contentHeight: number, scrollTop: number): number => {
-  if (contentHeight <= 0 || !Number.isFinite(contentHeight)) {
+export const getScrollBarTop = (height: number, contentHeight: number, scrollTop: number, scrollBarHeight: number): number => {
+  const finalScrollTop = contentHeight - height
+  if (finalScrollTop <= 0 || !Number.isFinite(finalScrollTop)) {
     return 0
   }
-  const scrollBarTop = Math.round((scrollTop / contentHeight) * height)
+  const scrollBarTop = Math.round((scrollTop / finalScrollTop) * (height - scrollBarHeight))
   if (!Number.isFinite(scrollBarTop)) {
     return 0
   }

--- a/packages/explorer-view/src/parts/RenderCss/RenderCss.ts
+++ b/packages/explorer-view/src/parts/RenderCss/RenderCss.ts
@@ -25,8 +25,8 @@ export const renderCss = (oldState: ExplorerState, newState: ExplorerState): rea
   } = newState
   const uniqueIndents = getUniqueIndents(visibleExplorerItems)
   const contentHeight = items.length * itemHeight
-  const scrollBarTop = getScrollBarTop(height, contentHeight, deltaY)
   const scrollBarHeight = getScrollBarSize(height, contentHeight, 20)
+  const scrollBarTop = getScrollBarTop(height, contentHeight, deltaY, scrollBarHeight)
   const depth = items[focusedIndex]?.depth || 0
   const { errorMessageWidth, left, top } = GetErrorMessagePosition.getErrorMessagePosition(
     itemHeight,

--- a/packages/explorer-view/test/GetScrollBarTop.test.ts
+++ b/packages/explorer-view/test/GetScrollBarTop.test.ts
@@ -6,11 +6,11 @@ test('getScrollBarTop - no scrollbar', () => {
 })
 
 test('getScrollBarTop - invalid content height', () => {
-  expect(getScrollBarTop(100, Number.NaN, 0, 0)).toBe(0)
+  expect(getScrollBarTop(100, NaN, 0, 0)).toBe(0)
 })
 
 test('getScrollBarTop - invalid scroll top', () => {
-  expect(getScrollBarTop(100, 200, Number.NaN, 50)).toBe(0)
+  expect(getScrollBarTop(100, 200, NaN, 50)).toBe(0)
 })
 
 test('getScrollBarTop - top', () => {

--- a/packages/explorer-view/test/GetScrollBarTop.test.ts
+++ b/packages/explorer-view/test/GetScrollBarTop.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@jest/globals'
+import { getScrollBarTop } from '../src/parts/GetScrollBarTop/GetScrollBarTop.ts'
+
+test('getScrollBarTop - no scrollbar', () => {
+  expect(getScrollBarTop(100, 100, 0, 0)).toBe(0)
+})
+
+test('getScrollBarTop - invalid content height', () => {
+  expect(getScrollBarTop(100, Number.NaN, 0, 0)).toBe(0)
+})
+
+test('getScrollBarTop - invalid scroll top', () => {
+  expect(getScrollBarTop(100, 200, Number.NaN, 50)).toBe(0)
+})
+
+test('getScrollBarTop - top', () => {
+  expect(getScrollBarTop(100, 200, 0, 50)).toBe(0)
+})
+
+test('getScrollBarTop - middle', () => {
+  expect(getScrollBarTop(100, 200, 50, 50)).toBe(25)
+})
+
+test('getScrollBarTop - bottom', () => {
+  expect(getScrollBarTop(100, 200, 100, 50)).toBe(50)
+})
+
+test('getScrollBarTop - bottom with minimum scrollbar height', () => {
+  expect(getScrollBarTop(100, 1000, 900, 20)).toBe(80)
+})


### PR DESCRIPTION
Fix the explorer scrollbar position calculation so the thumb stays within its track when the minimum thumb size applies. Adds focused regression coverage for top, middle, bottom, and minimum-size geometry.