### PR TITLE
fix: allow expanded explorer e2e suite to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless -- --timeout=1200000
+        run: npm run e2e:firefox:headless -- --timeout=1500000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,7 +52,7 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: e2e firefox
         working-directory: ./packages/e2e
-        run: npm run e2e:firefox:headless -- --timeout=1200000
+        run: npm run e2e:firefox:headless -- --timeout=1500000
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
       - name: measure


### PR DESCRIPTION
Raises the Firefox aggregate e2e timeout from 20 to 25 minutes so the expanded Explorer suite can complete on slower Windows runners.