### PR TITLE
fix: ignore new dirent without workspace

### DIFF
--- a/packages/e2e/src/viewlet.explorer-new-file-with-no-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-new-file-with-no-workspace.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-new-file-with-no-workspace'
 
-export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const firstWorkspace = `${tmpDir}/first-workspace`
@@ -15,8 +15,7 @@ export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => 
   await Workspace.setPath('')
 
   // act
-  const newFileButton = Locator('button[name="NewFile"]')
-  await newFileButton.click()
+  await Explorer.newFile()
   await Workspace.setPath(secondWorkspace)
 
   // assert

--- a/packages/e2e/src/viewlet.explorer-new-file-with-no-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-new-file-with-no-workspace.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-new-file-with-no-workspace'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstWorkspace = `${tmpDir}/first-workspace`
+  const secondWorkspace = `${tmpDir}/second-workspace`
+  await FileSystem.mkdir(firstWorkspace)
+  await FileSystem.mkdir(secondWorkspace)
+  await FileSystem.writeFile(`${firstWorkspace}/first.txt`, '')
+  await FileSystem.writeFile(`${secondWorkspace}/second.txt`, '')
+  await Workspace.setPath(firstWorkspace)
+  await Workspace.setPath('')
+
+  // act
+  const newFileButton = Locator('button[name="NewFile"]')
+  await newFileButton.click()
+  await Workspace.setPath(secondWorkspace)
+
+  // assert
+  const input = Locator('.Explorer input')
+  const firstFile = Locator('.TreeItem[aria-label="first.txt"]')
+  const secondFile = Locator('.TreeItem[aria-label="second.txt"]')
+  await expect(input).toHaveCount(0)
+  await expect(firstFile).toHaveCount(0)
+  await expect(secondFile).toBeVisible()
+}

--- a/packages/e2e/src/viewlet.explorer-new-folder-with-no-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-new-folder-with-no-workspace.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-new-folder-with-no-workspace'
+
+export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  const firstWorkspace = `${tmpDir}/first-workspace`
+  const secondWorkspace = `${tmpDir}/second-workspace`
+  await FileSystem.mkdir(firstWorkspace)
+  await FileSystem.mkdir(secondWorkspace)
+  await FileSystem.writeFile(`${firstWorkspace}/first.txt`, '')
+  await FileSystem.writeFile(`${secondWorkspace}/second.txt`, '')
+  await Workspace.setPath(firstWorkspace)
+  await Workspace.setPath('')
+
+  // act
+  const newFolderButton = Locator('button[name="NewFolder"]')
+  await newFolderButton.click()
+  await Workspace.setPath(secondWorkspace)
+
+  // assert
+  const input = Locator('.Explorer input')
+  const firstFile = Locator('.TreeItem[aria-label="first.txt"]')
+  const secondFile = Locator('.TreeItem[aria-label="second.txt"]')
+  await expect(input).toHaveCount(0)
+  await expect(firstFile).toHaveCount(0)
+  await expect(secondFile).toBeVisible()
+}

--- a/packages/e2e/src/viewlet.explorer-new-folder-with-no-workspace.ts
+++ b/packages/e2e/src/viewlet.explorer-new-folder-with-no-workspace.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-new-folder-with-no-workspace'
 
-export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   const firstWorkspace = `${tmpDir}/first-workspace`
@@ -15,8 +15,7 @@ export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => 
   await Workspace.setPath('')
 
   // act
-  const newFolderButton = Locator('button[name="NewFolder"]')
-  await newFolderButton.click()
+  await Explorer.newFolder()
   await Workspace.setPath(secondWorkspace)
 
   // assert

--- a/packages/explorer-view/src/parts/NewFile/NewFile.ts
+++ b/packages/explorer-view/src/parts/NewFile/NewFile.ts
@@ -4,7 +4,7 @@ import * as NewDirent from '../NewDirent/NewDirent.ts'
 
 // TODO much shared logic with newFolder
 export const newFile = (state: ExplorerState): Promise<ExplorerState> => {
-  if (state.isReadonly) {
+  if (state.root === '' || state.isReadonly) {
     return Promise.resolve(state)
   }
   return NewDirent.newDirent(state, ExplorerEditingType.CreateFile)

--- a/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
+++ b/packages/explorer-view/src/parts/NewFolder/NewFolder.ts
@@ -4,7 +4,7 @@ import { getEditingIcon } from '../GetEditingIcon/GetEditingIcon.ts'
 import * as NewDirent from '../NewDirent/NewDirent.ts'
 
 export const newFolder = async (state: ExplorerState): Promise<ExplorerState> => {
-  if (state.isReadonly || state.editingIndex !== -1) {
+  if (state.root === '' || state.isReadonly || state.editingIndex !== -1) {
     return state
   }
   const editingIcon = await getEditingIcon(ExplorerEditingType.CreateFolder, '')

--- a/packages/explorer-view/test/NewFile.test.ts
+++ b/packages/explorer-view/test/NewFile.test.ts
@@ -78,3 +78,14 @@ test('newFile', async () => {
   })
   expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/testfolder']])
 })
+
+test('newFile - no workspace', async () => {
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    root: '',
+  }
+
+  const result = await newFile(state)
+
+  expect(result).toBe(state)
+})

--- a/packages/explorer-view/test/NewFolder.test.ts
+++ b/packages/explorer-view/test/NewFolder.test.ts
@@ -60,3 +60,14 @@ test('newFolder', async () => {
   })
   expect(mockRpc.invocations).toEqual([['IconTheme.getFolderIcon', { name: '' }]])
 })
+
+test('newFolder - no workspace', async () => {
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    root: '',
+  }
+
+  const result = await newFolder(state)
+
+  expect(result).toBe(state)
+})


### PR DESCRIPTION
Prevents New File and New Folder from creating stale Explorer edit state when no workspace folder is open. Adds regression coverage for closing one workspace, clicking each toolbar action, and opening a different workspace.