### PR TITLE
fix: verify explorer sidebar title reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3089,9 +3089,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.93.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.9.tgz",
-      "integrity": "sha512-81Ax58WNab+z8+9Ms9mLC/cTNAkVc1bLrzC75XuITRbWxLV/+9K/TOL7yP/jelT5KtN5ADH/B8UBbZIAI/RgbA==",
+      "version": "0.93.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.12.tgz",
+      "integrity": "sha512-AQbZvHTMIBulHUOLCPIt+KtvXCiy3cN7u+TUtOlvxY5or3bLbF+fA2twQW0GGDeJKzy84D34cdcFcd4WO/wwmQ==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -4042,13 +4042,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.93.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.9.tgz",
-      "integrity": "sha512-MWci/XbGpbAqpOylEJbdPiNHSW1Pffi/+dWMmc8/syEVR6U+8zjlq/tbBWrSymL0UREbX++bPBaJaSJwl+T5ow==",
+      "version": "0.93.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.12.tgz",
+      "integrity": "sha512-Erlg36kOb43VfFekGyDj3fnch2mwBx7U7U3cdtJBsNcfw5SnSzfNsKdsk7KTtvM4c8xBNyneuu3yHVejcsrc1w==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.93.9",
-        "@lvce-editor/static-server": "0.93.9"
+        "@lvce-editor/shared-process": "0.93.12",
+        "@lvce-editor/static-server": "0.93.12"
       },
       "bin": {
         "server": "bin/server.js"
@@ -4058,14 +4058,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.93.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.9.tgz",
-      "integrity": "sha512-Bo6kZ7et3Og/RgwXpOMtwwmgaRtpPc/Tc7FH3pK8iGRyaXATmaMWI2c3W5GEqpfW2ckOQw7WpazOHKs4v/5Y8w==",
+      "version": "0.93.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.12.tgz",
+      "integrity": "sha512-37+yBnNkzwc8/M9ygOhs5M3LhYGhN4SBNDQlnqpHyAyUSBjkzSxLJTri38GkCSY9jYIOtXYUoC+hQWT6mLTGSA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.93.9",
+        "@lvce-editor/extension-host-helper-process": "0.93.12",
         "@lvce-editor/ipc": "16.4.0",
         "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -4103,9 +4103,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.93.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.9.tgz",
-      "integrity": "sha512-dyZANZDBngxch4jmkt+V47dbDsJAv8pjPQyK9GnAs/PEBs7zlGcJslzvqXa1jhkftd/dHoshgmoVwDWCAt/+7A==",
+      "version": "0.93.12",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.12.tgz",
+      "integrity": "sha512-fvdIYzOE5p5ey++IuA8FZQ65Mi17yM2FY7b8ChHcAVSqGWn+dMEPyB9WN9CoizRbxMLrhpNosAZLCCqjn/kxMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -17209,7 +17209,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.93.9"
+        "@lvce-editor/server": "0.93.12"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"

--- a/packages/e2e/src/viewlet.explorer-close-workspace-resets-sidebar-title.ts
+++ b/packages/e2e/src/viewlet.explorer-close-workspace-resets-sidebar-title.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-close-workspace-resets-sidebar-title'
+
+export const test: Test = async ({ expect, FileSystem, Locator, SideBar, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await Workspace.close()
+  await Workspace.setPath(tmpDir)
+  await SideBar.open('Search')
+  await SideBar.open('Explorer')
+  const title = Locator('.SideBarTitleAreaTitle')
+  const workspaceName = tmpDir.slice(tmpDir.lastIndexOf('/') + 1)
+  await expect(title).toHaveText(workspaceName)
+
+  // act
+  await Workspace.close()
+
+  // assert
+  await expect(title).toHaveText('Explorer')
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.93.9"
+    "@lvce-editor/server": "0.93.12"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"


### PR DESCRIPTION
## Summary

- add an e2e regression test that closes an open workspace and expects the Explorer sidebar title
- update the test server to the renderer release containing the title reset fix