### PR TITLE
fix: preserve initial explorer item indent

### DIFF
--- a/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetExplorerItemVirtualDom/GetExplorerItemVirtualDom.ts
@@ -23,6 +23,7 @@ export const getExplorerItemVirtualDom = (item: VisibleExplorerItem, editingSess
     hasEditingError,
     icon,
     id,
+    indent,
     index,
     isCut,
     isEditing,
@@ -47,6 +48,8 @@ export const getExplorerItemVirtualDom = (item: VisibleExplorerItem, editingSess
       'data-index': index,
       draggable: true,
       id,
+      // Keep the item aligned even when the generated indent stylesheet is applied late.
+      paddingLeft: indent,
       role: AriaRoles.TreeItem,
       title: getTitle(path),
       type: VirtualDomElements.Div,

--- a/packages/explorer-view/test/GetExplorerItemVirtualDom.test.ts
+++ b/packages/explorer-view/test/GetExplorerItemVirtualDom.test.ts
@@ -11,7 +11,7 @@ test('basic item', () => {
     hasEditingError: false,
     icon: 'file',
     id: '1',
-    indent: 0,
+    indent: 34,
     index: 0,
     isCut: false,
     isEditing: false,
@@ -28,6 +28,7 @@ test('basic item', () => {
   expect(dom[0].role).toBe('treeitem')
   expect(dom[0].ariaLabel).toBe('test.txt')
   expect(dom[0].ariaSelected).toBeUndefined()
+  expect(dom[0].paddingLeft).toBe(34)
   expect(dom[0].title).toBe('/test.txt')
 })
 


### PR DESCRIPTION
Ensures explorer rows carry their indentation directly in the virtual DOM so files stay aligned when generated indent CSS is applied late. Adds a regression assertion for the row padding.