### PR TITLE
fix: clear cut items on escape

### DIFF
--- a/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-cut-file'
 
-export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, Command, ContextMenu, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -21,6 +21,7 @@ export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, Fil
 
   // act - cancel the cut operation
   await KeyBoard.press('Escape')
+  await Command.execute('Timeout.sleep', 100)
 
   // assert - file should no longer have cut decoration
   await expect(treeItemLabel).toHaveJSProperty('className', 'Label')

--- a/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-cut-file.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-context-menu-cut-file'
 
-export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   const tmpDir = await FileSystem.getTmpDir()
@@ -18,4 +18,10 @@ export const test: Test = async ({ ClipBoard, ContextMenu, expect, Explorer, Fil
   const treeItem = Locator('.TreeItem[data-index="1"]')
   const treeItemLabel = treeItem.locator('.Label')
   await expect(treeItemLabel).toHaveClass('LabelCut')
+
+  // act - cancel the cut operation
+  await KeyBoard.press('Escape')
+
+  // assert - file should no longer have cut decoration
+  await expect(treeItemLabel).toHaveJSProperty('className', 'Label')
 }

--- a/packages/explorer-view/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/explorer-view/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -95,7 +95,7 @@ export const getKeyBindings = (): readonly KeyBinding[] => {
       when: WhenExpression.FocusExplorer,
     },
     {
-      command: 'Explorer.focusNone',
+      command: 'Explorer.handleEscape',
       key: KeyCode.Escape,
       when: WhenExpression.FocusExplorer,
     },
@@ -107,11 +107,6 @@ export const getKeyBindings = (): readonly KeyBinding[] => {
     {
       command: 'Explorer.handleClickCurrent',
       key: KeyCode.Enter,
-      when: WhenExpression.FocusExplorer,
-    },
-    {
-      command: 'Explorer.handleEscape',
-      key: KeyCode.Escape,
       when: WhenExpression.FocusExplorer,
     },
     {

--- a/packages/explorer-view/src/parts/HandleCut/HandleCut.ts
+++ b/packages/explorer-view/src/parts/HandleCut/HandleCut.ts
@@ -1,5 +1,8 @@
+import { WhenExpression } from '@lvce-editor/constants'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ClipBoard from '../ClipBoard/ClipBoard.ts'
+import * as FocusId from '../FocusId/FocusId.ts'
 import { getSelectedItems } from '../GetSelectedItems/GetSelectedItems.ts'
 
 export const handleCut = async (state: ExplorerState): Promise<ExplorerState> => {
@@ -15,9 +18,12 @@ export const handleCut = async (state: ExplorerState): Promise<ExplorerState> =>
   }
   const files = dirents.map((dirent) => dirent.path)
   await ClipBoard.writeNativeFiles('cut', files)
+  await RendererWorker.invoke('Focus.setFocus', WhenExpression.FocusExplorer)
   return {
     ...state,
     cutItems: files,
+    focus: FocusId.List,
+    focused: true,
     pasteShouldMove: true,
   }
 }

--- a/packages/explorer-view/src/parts/HandleEscape/HandleEscape.ts
+++ b/packages/explorer-view/src/parts/HandleEscape/HandleEscape.ts
@@ -1,8 +1,9 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as FocusNone from '../FocusNone/FocusNone.ts'
 
 export const handleEscape = async (state: ExplorerState): Promise<ExplorerState> => {
   return {
-    ...state,
+    ...FocusNone.focusNone(state),
     cutItems: [],
   }
 }

--- a/packages/explorer-view/test/GetKeyBindings.test.ts
+++ b/packages/explorer-view/test/GetKeyBindings.test.ts
@@ -1,7 +1,22 @@
 import { expect, test } from '@jest/globals'
+import { WhenExpression } from '@lvce-editor/constants'
+import { KeyCode } from '@lvce-editor/virtual-dom-worker'
 import { getKeyBindings } from '../src/parts/GetKeyBindings/GetKeyBindings.ts'
 
 test('getKeyBindings', () => {
   const keyBindings = getKeyBindings()
   expect(keyBindings).toBeDefined()
+})
+
+test('registers one explorer Escape keybinding', () => {
+  const keyBindings = getKeyBindings()
+  const escapeKeyBindings = keyBindings.filter(({ key, when }) => key === KeyCode.Escape && when === WhenExpression.FocusExplorer)
+
+  expect(escapeKeyBindings).toEqual([
+    {
+      command: 'Explorer.handleEscape',
+      key: KeyCode.Escape,
+      when: WhenExpression.FocusExplorer,
+    },
+  ])
 })

--- a/packages/explorer-view/test/HandleCut.test.ts
+++ b/packages/explorer-view/test/HandleCut.test.ts
@@ -3,23 +3,31 @@ import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import * as FocusId from '../src/parts/FocusId/FocusId.ts'
 import { handleCut } from '../src/parts/HandleCut/HandleCut.ts'
 
 test('handleCut - with focused dirent', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeNativeFiles'() {},
+    'Focus.setFocus'() {},
   })
   const state: ExplorerState = {
     ...createDefaultState(),
+    focused: false,
     focusedIndex: 0,
     items: [{ depth: 0, name: 'test.txt', path: '/test.txt', selected: false, type: DirentType.File }],
   }
   const result = await handleCut(state)
 
-  expect(mockRpc.invocations).toEqual([['ClipBoard.writeNativeFiles', 'cut', ['/test.txt']]])
+  expect(mockRpc.invocations).toEqual([
+    ['ClipBoard.writeNativeFiles', 'cut', ['/test.txt']],
+    ['Focus.setFocus', 13],
+  ])
   expect(result).toEqual({
     ...state,
     cutItems: ['/test.txt'],
+    focus: FocusId.List,
+    focused: true,
     pasteShouldMove: true,
   })
 })

--- a/packages/explorer-view/test/HandleEscape.test.ts
+++ b/packages/explorer-view/test/HandleEscape.test.ts
@@ -3,7 +3,7 @@ import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleEscape } from '../src/parts/HandleEscape/HandleEscape.ts'
 
-test('handleEscape - clears cutItems and keeps other state', async () => {
+test('handleEscape - clears cutItems and focus', async () => {
   const initialState: ExplorerState = {
     ...createDefaultState(),
     cutItems: ['/a/b.txt', '/c/d.txt'],
@@ -13,5 +13,5 @@ test('handleEscape - clears cutItems and keeps other state', async () => {
   const result = await handleEscape(initialState)
 
   expect(result.cutItems).toEqual([])
-  expect(result.focusedIndex).toBe(1)
+  expect(result.focusedIndex).toBe(-1)
 })

--- a/packages/explorer-view/test/PasteShouldMove.test.ts
+++ b/packages/explorer-view/test/PasteShouldMove.test.ts
@@ -10,6 +10,7 @@ import { handlePaste } from '../src/parts/HandlePaste/HandlePaste.ts'
 test('pasteShouldMove should be true after cut operation', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeNativeFiles'() {},
+    'Focus.setFocus'() {},
   })
 
   const state: ExplorerState = {
@@ -21,7 +22,10 @@ test('pasteShouldMove should be true after cut operation', async () => {
   const result = await handleCut(state)
 
   expect(result.pasteShouldMove).toBe(true)
-  expect(mockRpc.invocations).toEqual([['ClipBoard.writeNativeFiles', 'cut', ['/test.txt']]])
+  expect(mockRpc.invocations).toEqual([
+    ['ClipBoard.writeNativeFiles', 'cut', ['/test.txt']],
+    ['Focus.setFocus', 13],
+  ])
 })
 
 test('pasteShouldMove should be false after copy operation', async () => {


### PR DESCRIPTION
## Summary

- clear Explorer cut decorations when Escape is pressed
- preserve the existing focus-clearing behavior through one Escape keybinding
- cover context-menu Cut followed by a real Escape keypress in e2e