### PR TITLE
fix: copy path for scrolled explorer items

### DIFF
--- a/packages/e2e/src/viewlet.explorer-context-menu-copy-path-scrolled.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-copy-path-scrolled.ts
@@ -1,0 +1,24 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-context-menu-copy-path-scrolled'
+
+export const test: Test = async ({ ClipBoard, ContextMenu, Explorer, FileSystem, Workspace }) => {
+  // arrange
+  await ClipBoard.enableMemoryClipBoard()
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFiles(
+    Array.from({ length: 80 }, (_, index) => ({
+      content: '',
+      uri: `${tmpDir}/file-${index.toString().padStart(2, '0')}.txt`,
+    })),
+  )
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(40)
+
+  // act
+  await Explorer.openContextMenu(40)
+  await ContextMenu.selectItem('Copy Path')
+
+  // assert
+  await ClipBoard.shouldHaveText('memfs:///workspace/file-40.txt')
+}

--- a/packages/explorer-view/src/parts/GetFocusedDirent/GetFocusedDirent.ts
+++ b/packages/explorer-view/src/parts/GetFocusedDirent/GetFocusedDirent.ts
@@ -2,7 +2,7 @@ import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 
 export const getFocusedDirent = (state: ExplorerState): ExplorerItem | undefined => {
-  const { focusedIndex, items, minLineY } = state
-  const dirent = items[focusedIndex + minLineY]
+  const { focusedIndex, items } = state
+  const dirent = items[focusedIndex]
   return dirent
 }

--- a/packages/explorer-view/test/CopyPath.test.ts
+++ b/packages/explorer-view/test/CopyPath.test.ts
@@ -24,6 +24,30 @@ test('copyPath - writes absolute path of focused dirent to clipboard', async () 
   expect(mockRpc.invocations).toEqual([['ClipBoard.writeText', '/test/file.txt']])
 })
 
+test('copyPath - writes absolute path of focused dirent when scrolled', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.writeText'(text: string) {
+      return
+    },
+  })
+
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 1,
+    items: [
+      { depth: 0, name: 'first.txt', path: '/test/first.txt', selected: false, type: DirentType.File },
+      { depth: 0, name: 'focused.txt', path: '/test/focused.txt', selected: false, type: DirentType.File },
+      { depth: 0, name: 'last.txt', path: '/test/last.txt', selected: false, type: DirentType.File },
+    ],
+    minLineY: 1,
+  }
+
+  const result = await copyPath(state)
+
+  expect(result).toBe(state)
+  expect(mockRpc.invocations).toEqual([['ClipBoard.writeText', '/test/focused.txt']])
+})
+
 test('copyPath - writes workspace path when no focused dirent', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeText'(text: string) {


### PR DESCRIPTION
Fix Copy Path and other focused-item actions using the wrong row after the Explorer is scrolled. Adds unit and end-to-end regression coverage for a nonzero scroll offset.