### PR TITLE
feature: open explorer item in terminal

### DIFF
--- a/packages/e2e/src/viewlet.explorer-context-menu-open-in-integrated-terminal.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-open-in-integrated-terminal.ts
@@ -1,0 +1,35 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-context-menu-open-in-integrated-terminal'
+
+export const skip = 1
+
+export const test: Test = async ({ Command, ContextMenu, expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
+  // arrange
+  await Settings.update({
+    'terminal.backend': 'mock',
+  })
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder`)
+  await FileSystem.writeFile(`${tmpDir}/folder/file.txt`, '')
+  await Workspace.setPath(tmpDir)
+  await Explorer.expandRecursively()
+  await Explorer.focusIndex(1)
+
+  // act
+  await Explorer.openContextMenu(1)
+  await ContextMenu.selectItem('Open in integrated Terminal')
+
+  // assert
+  const panel = Locator('.Panel')
+  const terminal = Locator('.XtermTerminal')
+  const terminalInput = terminal.locator('.xterm-helper-textarea')
+  await expect(panel).toBeVisible()
+  await expect(terminal).toBeVisible()
+  await expect(terminalInput).toBeFocused()
+  const states = await Command.execute('Viewlet.getAllStates')
+  const terminalState = Object.values(states).find((state: any) => state.cwd === 'memfs:///workspace/folder')
+  if (!terminalState) {
+    throw new Error('Expected a terminal in memfs:///workspace/folder')
+  }
+}

--- a/packages/e2e/src/viewlet.explorer-context-menu-open-in-integrated-terminal.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-open-in-integrated-terminal.ts
@@ -4,6 +4,10 @@ export const name = 'viewlet.explorer-context-menu-open-in-integrated-terminal'
 
 export const skip = 1
 
+const hasTerminalWithCwd = (states: any, expectedCwd: string): boolean => {
+  return Object.values(states).some(({ cwd }: any) => cwd === expectedCwd)
+}
+
 export const test: Test = async ({ Command, ContextMenu, expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({
@@ -28,8 +32,8 @@ export const test: Test = async ({ Command, ContextMenu, expect, Explorer, FileS
   await expect(terminal).toBeVisible()
   await expect(terminalInput).toBeFocused()
   const states = await Command.execute('Viewlet.getAllStates')
-  const terminalState = Object.values(states).find((state: any) => state.cwd === 'memfs:///workspace/folder')
-  if (!terminalState) {
+  const hasExpectedTerminal = hasTerminalWithCwd(states, 'memfs:///workspace/folder')
+  if (!hasExpectedTerminal) {
     throw new Error('Expected a terminal in memfs:///workspace/folder')
   }
 }

--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -68,6 +68,7 @@ import * as LoadContent from '../LoadContent/LoadContent.ts'
 import * as NewFile from '../NewFile/NewFile.ts'
 import * as NewFolder from '../NewFolder/NewFolder.ts'
 import * as OpenContainingFolder from '../OpenContainingFolder/OpenContainingFolder.ts'
+import * as OpenInIntegratedTerminal from '../OpenInIntegratedTerminal/OpenInIntegratedTerminal.ts'
 import * as Refresh from '../Refresh/Refresh.ts'
 import * as RemoveDirent from '../RemoveDirent/RemoveDirent.ts'
 import * as RenameDirent from '../RenameDirent/RenameDirent.ts'
@@ -158,6 +159,7 @@ export const commandMap = {
   'Explorer.newFile': WrapCommand.wrapListItemCommand(NewFile.newFile),
   'Explorer.newFolder': WrapCommand.wrapListItemCommand(NewFolder.newFolder),
   'Explorer.openContainingFolder': WrapCommand.wrapListItemCommand(OpenContainingFolder.openContainingFolder),
+  'Explorer.openInIntegratedTerminal': WrapCommand.wrapListItemCommand(OpenInIntegratedTerminal.openInIntegratedTerminal),
   'Explorer.refresh': WrapCommand.wrapListItemCommand(Refresh.refresh),
   'Explorer.removeDirent': WrapCommand.wrapListItemCommand(RemoveDirent.removeDirent),
   'Explorer.renameDirent': WrapCommand.wrapListItemCommand(RenameDirent.renameDirent),

--- a/packages/explorer-view/src/parts/GetIntegratedTerminalCwd/GetIntegratedTerminalCwd.ts
+++ b/packages/explorer-view/src/parts/GetIntegratedTerminalCwd/GetIntegratedTerminalCwd.ts
@@ -1,0 +1,17 @@
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as DirentType from '../DirentType/DirentType.ts'
+import * as Path from '../Path/Path.ts'
+
+const directoryTypes = new Set([DirentType.Directory, DirentType.DirectoryExpanded, DirentType.DirectoryExpanding, DirentType.SymLinkFolder])
+
+export const getIntegratedTerminalCwd = (state: ExplorerState): string => {
+  const { focusedIndex, items, pathSeparator, root } = state
+  if (focusedIndex < 0 || focusedIndex >= items.length) {
+    return root
+  }
+  const item = items[focusedIndex]
+  if (directoryTypes.has(item.type)) {
+    return item.path
+  }
+  return Path.dirname(pathSeparator, item.path)
+}

--- a/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
+++ b/packages/explorer-view/src/parts/GetMenuEntries/GetMenuEntries.ts
@@ -28,7 +28,7 @@ const menuEntryOpenContainingFolder: MenuEntry = {
 }
 
 const menuEntryOpenInIntegratedTerminal: MenuEntry = {
-  command: /* TODO */ '-1',
+  command: 'Explorer.openInIntegratedTerminal',
   flags: MenuItemFlags.None,
   id: 'openInIntegratedTerminal',
   label: ViewletExplorerStrings.openInIntegratedTerminal(),

--- a/packages/explorer-view/src/parts/OpenInIntegratedTerminal/OpenInIntegratedTerminal.ts
+++ b/packages/explorer-view/src/parts/OpenInIntegratedTerminal/OpenInIntegratedTerminal.ts
@@ -1,0 +1,9 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import { getIntegratedTerminalCwd } from '../GetIntegratedTerminalCwd/GetIntegratedTerminalCwd.ts'
+
+export const openInIntegratedTerminal = async (state: ExplorerState): Promise<ExplorerState> => {
+  const cwd = getIntegratedTerminalCwd(state)
+  await RendererWorker.invoke('Layout.openIntegratedTerminal', cwd)
+  return state
+}

--- a/packages/explorer-view/test/OpenInIntegratedTerminal.test.ts
+++ b/packages/explorer-view/test/OpenInIntegratedTerminal.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import { openInIntegratedTerminal } from '../src/parts/OpenInIntegratedTerminal/OpenInIntegratedTerminal.ts'
+
+test('opens a terminal in the focused directory', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.openIntegratedTerminal'() {},
+  })
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [{ depth: 0, name: 'folder', path: 'file:///workspace/folder', selected: true, type: DirentType.Directory }],
+  }
+
+  await expect(openInIntegratedTerminal(state)).resolves.toBe(state)
+  expect(mockRpc.invocations).toEqual([['Layout.openIntegratedTerminal', 'file:///workspace/folder']])
+})
+
+test('opens a terminal in the parent of the focused file', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.openIntegratedTerminal'() {},
+  })
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [{ depth: 0, name: 'file.txt', path: 'file:///workspace/folder/file.txt', selected: true, type: DirentType.File }],
+  }
+
+  await openInIntegratedTerminal(state)
+
+  expect(mockRpc.invocations).toEqual([['Layout.openIntegratedTerminal', 'file:///workspace/folder']])
+})
+
+test('opens a terminal in the workspace root when no item is focused', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.openIntegratedTerminal'() {},
+  })
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: -1,
+    root: 'file:///workspace',
+  }
+
+  await openInIntegratedTerminal(state)
+
+  expect(mockRpc.invocations).toEqual([['Layout.openIntegratedTerminal', 'file:///workspace']])
+})


### PR DESCRIPTION
Wire the explorer context-menu command to open an integrated terminal in the focused folder, or the parent folder for a focused file. Includes focused unit coverage and a dependent e2e regression scenario.