### PR TITLE
fix: delete selected folders from context menu

### DIFF
--- a/packages/e2e/src/viewlet.explorer-context-menu-delete-focused-folder-with-selection.ts
+++ b/packages/e2e/src/viewlet.explorer-context-menu-delete-focused-folder-with-selection.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-context-menu-delete-focused-folder-with-selection'
+
+export const test: Test = async ({ ContextMenu, Dialog, expect, Explorer, FileSystem, Locator, Workspace }) => {
+  // arrange
+  let confirmMessage = ''
+  await Dialog.mockConfirm((...args: readonly unknown[]) => {
+    confirmMessage = String(args[0])
+    return true
+  })
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.mkdir(`${tmpDir}/folder-1`)
+  await FileSystem.mkdir(`${tmpDir}/folder-2`)
+  await FileSystem.mkdir(`${tmpDir}/folder-3`)
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+  await Explorer.toggleIndividualSelection(1)
+  const folder1 = Locator('.TreeItem[aria-label="folder-1"]')
+  const folder2 = Locator('.TreeItem[aria-label="folder-2"]')
+  const folder3 = Locator('.TreeItem[aria-label="folder-3"]')
+  await expect(folder1).toHaveClass('TreeItemActive')
+  await expect(folder2).toHaveClass('TreeItemActive')
+
+  // act
+  await Explorer.openContextMenu(0)
+  await ContextMenu.selectItem('Delete')
+
+  // assert
+  if (confirmMessage !== 'Are you sure you want to delete "folder-1", "folder-2"?') {
+    throw new Error(`unexpected confirm message: ${confirmMessage}`)
+  }
+  await expect(folder1).toBeHidden()
+  await expect(folder2).toBeHidden()
+  await expect(folder3).toBeVisible()
+}

--- a/packages/explorer-view/src/parts/ConfirmDelete/ConfirmDelete.ts
+++ b/packages/explorer-view/src/parts/ConfirmDelete/ConfirmDelete.ts
@@ -3,10 +3,8 @@ import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 
 export const confirmDelete = async (items: readonly ExplorerItem[]): Promise<boolean> => {
   // TODO use i18n string
-  const message =
-    items.length === 1
-      ? `Are you sure you want to delete "${items[0].path}"?`
-      : `Are you sure you want to delete ${items.map((item) => `"${item.name}"`).join(', ')}?`
+  const names = items.map((item) => `"${item.name}"`).join(', ')
+  const message = items.length === 1 ? `Are you sure you want to delete "${items[0].path}"?` : `Are you sure you want to delete ${names}?`
   const result = await RendererWorker.confirm(message)
   return result
 }

--- a/packages/explorer-view/src/parts/ConfirmDelete/ConfirmDelete.ts
+++ b/packages/explorer-view/src/parts/ConfirmDelete/ConfirmDelete.ts
@@ -1,8 +1,12 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 
-export const confirmDelete = async (paths: readonly string[]): Promise<boolean> => {
+export const confirmDelete = async (items: readonly ExplorerItem[]): Promise<boolean> => {
   // TODO use i18n string
-  const message = paths.length === 1 ? `Are you sure you want to delete "${paths[0]}"?` : `Are you sure you want to delete ${paths.length} items?`
+  const message =
+    items.length === 1
+      ? `Are you sure you want to delete "${items[0].path}"?`
+      : `Are you sure you want to delete ${items.map((item) => `"${item.name}"`).join(', ')}?`
   const result = await RendererWorker.confirm(message)
   return result
 }

--- a/packages/explorer-view/src/parts/HandleContextMenuAtIndex/HandleContextMenuAtIndex.ts
+++ b/packages/explorer-view/src/parts/HandleContextMenuAtIndex/HandleContextMenuAtIndex.ts
@@ -7,10 +7,10 @@ import * as MenuEntryId from '../MenuEntryId/MenuEntryId.ts'
 export const handleContextMenuAtIndex = async (state: ExplorerState, index: number, x: number, y: number): Promise<ExplorerState> => {
   Assert.number(x)
   Assert.number(y)
-  const { items, uid } = state
+  const { focusedIndex, items, uid } = state
   const contextMenuItem = items[index]
   const newItems =
-    contextMenuItem && !contextMenuItem.selected
+    contextMenuItem && index !== focusedIndex && !contextMenuItem.selected
       ? items.map((item) => ({
           ...item,
           selected: false,

--- a/packages/explorer-view/src/parts/RemoveDirent/RemoveDirent.ts
+++ b/packages/explorer-view/src/parts/RemoveDirent/RemoveDirent.ts
@@ -21,7 +21,7 @@ export const removeDirent = async (state: ExplorerState): Promise<ExplorerState>
   const toRemove = getPaths(selectedItems)
 
   if (confirmDelete) {
-    const confirmed = await ConfirmDelete.confirmDelete(toRemove)
+    const confirmed = await ConfirmDelete.confirmDelete(selectedItems)
     if (!confirmed) {
       return state
     }

--- a/packages/explorer-view/test/ConfirmDelete.test.ts
+++ b/packages/explorer-view/test/ConfirmDelete.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import { confirmDelete } from '../src/parts/ConfirmDelete/ConfirmDelete.ts'
 
 test('confirmDelete - single file', async () => {
@@ -8,19 +9,22 @@ test('confirmDelete - single file', async () => {
       return true
     },
   })
-  const result = await confirmDelete(['/test/file.txt'])
+  const result = await confirmDelete([{ depth: 0, name: 'file.txt', path: '/test/file.txt', selected: false, type: DirentType.File }])
   expect(result).toBe(true)
   expect(mockRpc.invocations).toEqual([['ConfirmPrompt.prompt', 'Are you sure you want to delete "/test/file.txt"?', undefined]])
 })
 
-test('confirmDelete - multiple files', async () => {
+test('confirmDelete - multiple folders', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ConfirmPrompt.prompt'() {
       return false
     },
   })
 
-  const result = await confirmDelete(['/test/file1.txt', '/test/file2.txt', '/test/file3.txt'])
+  const result = await confirmDelete([
+    { depth: 0, name: 'folder-1', path: '/test/folder-1', selected: true, type: DirentType.Directory },
+    { depth: 0, name: 'folder-2', path: '/test/folder-2', selected: true, type: DirentType.Directory },
+  ])
   expect(result).toBe(false)
-  expect(mockRpc.invocations).toEqual([['ConfirmPrompt.prompt', 'Are you sure you want to delete 3 items?', undefined]])
+  expect(mockRpc.invocations).toEqual([['ConfirmPrompt.prompt', 'Are you sure you want to delete "folder-1", "folder-2"?', undefined]])
 })

--- a/packages/explorer-view/test/ConfirmDelete.test.ts
+++ b/packages/explorer-view/test/ConfirmDelete.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
-import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import { confirmDelete } from '../src/parts/ConfirmDelete/ConfirmDelete.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 
 test('confirmDelete - single file', async () => {
   using mockRpc = RendererWorker.registerMockRpc({

--- a/packages/explorer-view/test/HandleContextMenuAtIndex.test.ts
+++ b/packages/explorer-view/test/HandleContextMenuAtIndex.test.ts
@@ -46,3 +46,25 @@ test('handleContextMenuAtIndex - keeps selection when target is selected', async
   expect(result.focusedIndex).toBe(1)
   expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 1, 4, 100, 200, { menuId: 4 }]])
 })
+
+test('handleContextMenuAtIndex - keeps selection when target is focused', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ContextMenu.show2'() {},
+  })
+
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [
+      { depth: 1, name: 'a', path: '/a', selected: false, type: DirentType.Directory },
+      { depth: 1, name: 'b', path: '/b', selected: true, type: DirentType.Directory },
+      { depth: 1, name: 'c', path: '/c', selected: false, type: DirentType.Directory },
+    ],
+  }
+
+  const result = await handleContextMenuAtIndex(state, 0, 100, 200)
+
+  expect(result.items.map((item) => item.selected)).toEqual([false, true, false])
+  expect(result.focusedIndex).toBe(0)
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', 1, 4, 100, 200, { menuId: 4 }]])
+})


### PR DESCRIPTION
Fixes explorer context-menu deletion so right-clicking the focused member of a multi-selection preserves and deletes the full selection. The confirmation prompt now lists every selected folder name, with regression coverage for the focused-plus-selected state.