### PR TITLE
fix: clear drag highlight outside explorer

### DIFF
--- a/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-handle-drag-leave'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -11,15 +11,16 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Workspace.setPath(tmpDir)
 
   // act
-  await Explorer.handleDragOverIndex(-1)
+  const explorer = Locator('.Explorer .ListItems')
+  await explorer.dispatchEvent('dragover', { bubbles: true, clientX: 5000, clientY: 5000 } as any)
 
   // assert
-  const explorer = Locator('.Explorer .ListItems')
-  await expect(explorer).toHaveClass('DropTarget')
+  const dropTarget = Locator('.Explorer .ListItems.DropTarget')
+  await expect(dropTarget).toBeVisible()
 
   // act
-  await Explorer.handleDragLeave()
+  await explorer.dispatchEvent('dragleave', { bubbles: true } as any)
 
   // assert
-  await expect(explorer).not.toHaveClass('DropTarget')
+  await expect(dropTarget).toBeHidden()
 }

--- a/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-handle-drag-leave'
 
-export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -11,10 +11,10 @@ export const test: Test = async ({ expect, FileSystem, Locator, Workspace }) => 
   await Workspace.setPath(tmpDir)
 
   // act
-  const explorer = Locator('.Explorer .ListItems')
-  await explorer.dispatchEvent('dragover', { bubbles: true, clientX: 5000, clientY: 5000 } as any)
+  await Explorer.handleDragOver(5000, 5000)
 
   // assert
+  const explorer = Locator('.Explorer .ListItems')
   const dropTarget = Locator('.Explorer .ListItems.DropTarget')
   await expect(dropTarget).toBeVisible()
 

--- a/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
@@ -11,7 +11,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Workspace.setPath(tmpDir)
 
   // act
-  await Explorer.handleDragOver(5000, 5000)
+  await Explorer.handleDragOverIndex(-1)
 
   // assert
   const explorer = Locator('.Explorer .ListItems')

--- a/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-handle-drag-leave'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
@@ -20,6 +20,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
 
   // act
   await explorer.dispatchEvent('dragleave', { bubbles: true } as any)
+  await Command.execute('Timeout.sleep', 100)
 
   // assert
   await expect(dropTarget).toBeHidden()

--- a/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
+++ b/packages/e2e/src/viewlet.explorer-handle-drag-leave.ts
@@ -21,5 +21,5 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.handleDragLeave()
 
   // assert
-  // TODO
+  await expect(explorer).not.toHaveClass('DropTarget')
 }

--- a/packages/explorer-view/src/parts/HandleDragLeave/HandleDragLeave.ts
+++ b/packages/explorer-view/src/parts/HandleDragLeave/HandleDragLeave.ts
@@ -1,5 +1,12 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 
 export const handleDragLeave = (state: ExplorerState): ExplorerState => {
-  return state
+  const { dropTargets } = state
+  if (dropTargets.length === 0) {
+    return state
+  }
+  return {
+    ...state,
+    dropTargets: [],
+  }
 }

--- a/packages/explorer-view/test/HandleDragLeave.test.ts
+++ b/packages/explorer-view/test/HandleDragLeave.test.ts
@@ -2,8 +2,20 @@ import { test, expect } from '@jest/globals'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import { handleDragLeave } from '../src/parts/HandleDragLeave/HandleDragLeave.ts'
 
-test('handleDragLeave returns state unchanged', () => {
+test('handleDragLeave returns state unchanged when there are no drop targets', () => {
   const state = createDefaultState()
   const result = handleDragLeave(state)
   expect(result).toBe(state)
+})
+
+test('handleDragLeave clears drop targets', () => {
+  const state = {
+    ...createDefaultState(),
+    dropTargets: [1],
+  }
+  const result = handleDragLeave(state)
+  expect(result).toEqual({
+    ...state,
+    dropTargets: [],
+  })
 })


### PR DESCRIPTION
Clear explorer drop targets when a drag leaves the view so its highlight does not remain visible over the main area. Completes the existing drag-leave e2e regression.