### PR TITLE
fix: keep explorer focused when opening files

### DIFF
--- a/packages/e2e/src/viewlet.explorer-open-file-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-open-file-keeps-focus.ts
@@ -1,8 +1,8 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'viewlet.explorer-space-opens-file-and-keeps-focus'
+export const name = 'viewlet.explorer-open-file-keeps-focus'
 
-export const test: Test = async ({ Command, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, KeyBoa
   await expect(explorerItems).toBeFocused()
 
   // act
-  await KeyBoard.press(' ')
+  await Command.execute('Explorer.handleClickCurrentButKeepFocus')
 
   // assert
   const editorTab = Locator('.MainTab[title$="file.txt"]')

--- a/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
@@ -2,12 +2,15 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-space-opens-file-and-keeps-focus'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
   await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focus')
   await Explorer.focusIndex(0)
+  const explorerItems = Locator('.Explorer .ListItems')
+  await expect(explorerItems).toBeFocused()
 
   // act
   await KeyBoard.press('Space')
@@ -16,6 +19,5 @@ export const test: Test = async ({ expect, Explorer, FileSystem, KeyBoard, Locat
   const editorTab = Locator('.MainTab[title$="file.txt"]')
   await expect(editorTab).toBeVisible()
   await expect(editorTab).toHaveClass('MainTabPreview')
-  const explorerItems = Locator('.Explorer .ListItems')
   await expect(explorerItems).toBeFocused()
 }

--- a/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-space-opens-file-and-keeps-focus'
+
+export const test: Test = async ({ expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  await Explorer.focusIndex(0)
+
+  // act
+  await KeyBoard.press('Space')
+
+  // assert
+  const editorTab = Locator('.MainTab[title$="file.txt"]')
+  await expect(editorTab).toBeVisible()
+  await expect(editorTab).toHaveClass('MainTabPreview')
+  const explorerItems = Locator('.Explorer .ListItems')
+  await expect(explorerItems).toBeFocused()
+}

--- a/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-space-opens-file-and-keeps-focus.ts
@@ -13,7 +13,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, KeyBoa
   await expect(explorerItems).toBeFocused()
 
   // act
-  await KeyBoard.press('Space')
+  await KeyBoard.press(' ')
 
   // assert
   const editorTab = Locator('.MainTab[title$="file.txt"]')

--- a/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
+++ b/packages/explorer-view/src/parts/OpenUri/OpenUri.ts
@@ -11,7 +11,7 @@ export const openUri = async (uri: string, focus: boolean, options?: OpenUriOpti
         type: 'editor',
         uri,
       },
-      focu: focus,
+      focus,
       preview: options.preview ?? false,
     })
     return

--- a/packages/explorer-view/test/GetKeyBindings.test.ts
+++ b/packages/explorer-view/test/GetKeyBindings.test.ts
@@ -20,3 +20,16 @@ test('registers one explorer Escape keybinding', () => {
     },
   ])
 })
+
+test('registers Space to open the focused item without moving focus', () => {
+  const keyBindings = getKeyBindings()
+  const spaceKeyBindings = keyBindings.filter(({ key, when }) => key === KeyCode.Space && when === WhenExpression.FocusExplorer)
+
+  expect(spaceKeyBindings).toEqual([
+    {
+      command: 'Explorer.handleClickCurrentButKeepFocus',
+      key: KeyCode.Space,
+      when: WhenExpression.FocusExplorer,
+    },
+  ])
+})

--- a/packages/explorer-view/test/HandleClickSymlink.test.ts
+++ b/packages/explorer-view/test/HandleClickSymlink.test.ts
@@ -41,7 +41,7 @@ test('handleClickSymLink - file symlink', async () => {
           type: 'editor',
           uri: '/test/symlink',
         },
-        focu: true,
+        focus: true,
         preview: true,
       },
     ],

--- a/packages/explorer-view/test/OpenUri.test.ts
+++ b/packages/explorer-view/test/OpenUri.test.ts
@@ -38,7 +38,30 @@ test('openUri opens preview files through the main area input API', async () => 
           type: 'editor',
           uri: mockUri,
         },
-        focu: true,
+        focus: true,
+        preview: true,
+      },
+    ],
+  ])
+})
+
+test('openUri opens preview files without moving focus', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openInput'() {},
+  })
+  const mockUri = 'file:///test.txt'
+  await openUri(mockUri, false, {
+    preview: true,
+  })
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Main.openInput',
+      {
+        editorInput: {
+          type: 'editor',
+          uri: mockUri,
+        },
+        focus: false,
         preview: true,
       },
     ],


### PR DESCRIPTION
Fix Space-opening explorer files so the editor preview opens without taking focus from the explorer.

Add unit coverage for the main input focus option and an end-to-end regression test that presses Space and verifies explorer focus is retained.