### PR TITLE
fix: render explorer drag data on pointer down

### DIFF
--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -55,6 +55,7 @@ import * as HandleInputKeyDown from '../HandleInputKeyDown/HandleInputKeyDown.ts
 import * as HandleKeyDown from '../HandleKeyDown/HandleKeyDown.ts'
 import * as HandlePaste from '../HandlePaste/HandlePaste.ts'
 import * as HandlePointerDown from '../HandlePointerDown/HandlePointerDown.ts'
+import * as HandlePointerUp from '../HandlePointerUp/HandlePointerUp.ts'
 import * as HandleResize from '../HandleResize/HandleResize.ts'
 import { handleScrollBarCaptureLost } from '../HandleScrollBarCaptureLost/HandleScrollBarCaptureLost.ts'
 import { handleScrollBarClick } from '../HandleScrollBarClick/HandleScrollBarClick.ts'
@@ -146,6 +147,7 @@ export const commandMap = {
   'Explorer.handleKeyDown': WrapCommand.wrapListItemCommand(HandleKeyDown.handleKeyDown),
   'Explorer.handlePaste': WrapCommand.wrapListItemCommand(HandlePaste.handlePaste),
   'Explorer.handlePointerDown': WrapCommand.wrapListItemCommand(HandlePointerDown.handlePointerDown),
+  'Explorer.handlePointerUp': WrapCommand.wrapListItemCommand(HandlePointerUp.handlePointerUp),
   'Explorer.handleResize': WrapCommand.wrapListItemCommand(HandleResize.handleResize),
   'Explorer.handleScrollBarCaptureLost': WrapCommand.wrapListItemCommand(handleScrollBarCaptureLost),
   'Explorer.handleScrollBarClick': WrapCommand.wrapListItemCommand(handleScrollBarClick),

--- a/packages/explorer-view/src/parts/DiffDragData/DiffDragData.ts
+++ b/packages/explorer-view/src/parts/DiffDragData/DiffDragData.ts
@@ -1,5 +1,5 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 
 export const isEqual = (oldState: ExplorerState, newState: ExplorerState): boolean => {
-  return oldState.isPointerDown || !newState.isPointerDown
+  return oldState.isPointerDown === newState.isPointerDown && oldState.pointerDownIndex === newState.pointerDownIndex
 }

--- a/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -15,6 +15,7 @@ export const HandleKeyDown = 21
 export const HandleListBlur = 11
 export const HandleListFocus = 12
 export const HandlePointerDown = 14
+export const HandlePointerUp = 25
 export const HandleScrollBarMove = 22
 export const HandleScrollBarPointerCaptureLost = 23
 export const HandleScrollBarPointerDown = 24

--- a/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
@@ -48,6 +48,7 @@ export const getListItemsVirtualDom = (
       onDrop: DomEventListenerFunctions.HandleDrop,
       onFocus: DomEventListenerFunctions.HandleListFocus,
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
+      onPointerUp: DomEventListenerFunctions.HandlePointerUp,
       onWheel: DomEventListenerFunctions.HandleWheel,
       role: AriaRoles.Tree,
       tabIndex: TabIndex.Focusable,

--- a/packages/explorer-view/src/parts/HandleDragEnd/HandleDragEnd.ts
+++ b/packages/explorer-view/src/parts/HandleDragEnd/HandleDragEnd.ts
@@ -4,5 +4,7 @@ export const handleDragEnd = (state: ExplorerState): ExplorerState => {
   return {
     ...state,
     dropTargets: [],
+    isPointerDown: false,
+    pointerDownIndex: -1,
   }
 }

--- a/packages/explorer-view/src/parts/HandlePointerDown/HandlePointerDown.ts
+++ b/packages/explorer-view/src/parts/HandlePointerDown/HandlePointerDown.ts
@@ -13,5 +13,12 @@ export const handlePointerDown = (state: ExplorerState, button: number, x: numbe
       focusedIndex: -1,
     }
   }
+  if (button === MouseEventType.LeftClick) {
+    return {
+      ...state,
+      isPointerDown: true,
+      pointerDownIndex: index,
+    }
+  }
   return state
 }

--- a/packages/explorer-view/src/parts/HandlePointerUp/HandlePointerUp.ts
+++ b/packages/explorer-view/src/parts/HandlePointerUp/HandlePointerUp.ts
@@ -1,0 +1,13 @@
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+
+export const handlePointerUp = (state: ExplorerState): ExplorerState => {
+  const { isPointerDown, pointerDownIndex } = state
+  if (!isPointerDown && pointerDownIndex === -1) {
+    return state
+  }
+  return {
+    ...state,
+    isPointerDown: false,
+    pointerDownIndex: -1,
+  }
+}

--- a/packages/explorer-view/src/parts/RenderDragData/RenderDragData.ts
+++ b/packages/explorer-view/src/parts/RenderDragData/RenderDragData.ts
@@ -2,8 +2,11 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import { getDragData } from '../GetDragData/GetDragData.ts'
 
 export const renderDragData = (oldState: ExplorerState, newState: ExplorerState): readonly any[] => {
-  const { focusedIndex, items, uid } = newState
-  const selected = items.filter((item, index) => item.selected || index === focusedIndex)
+  const { isPointerDown, items, pointerDownIndex, uid } = newState
+  if (!isPointerDown) {
+    return []
+  }
+  const selected = items.filter((item, index) => item.selected || index === pointerDownIndex)
   const urls = selected.map((item) => item.path)
   const dragData = getDragData(urls)
   return ['Viewlet.setDragData', uid, dragData]

--- a/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -48,6 +48,10 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       params: ['handlePointerDown', EventExpression.Button, EventExpression.ClientX, EventExpression.ClientY],
     },
     {
+      name: DomEventListenersFunctions.HandlePointerUp,
+      params: ['handlePointerUp'],
+    },
+    {
       name: DomEventListenersFunctions.HandleScrollBarPointerDown,
       params: ['handleScrollBarClick', EventExpression.ClientY],
       preventDefault: true,

--- a/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
+++ b/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@jest/globals'
+import { getListItemsVirtualDom } from '../src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts'
+
+test('registers pointer lifecycle handlers on the explorer tree', () => {
+  const [tree] = getListItemsVirtualDom([], -1, false, [])
+
+  expect(tree).toMatchObject({
+    onPointerDown: 14,
+    onPointerUp: 25,
+  })
+})

--- a/packages/explorer-view/test/HandleDragEnd.test.ts
+++ b/packages/explorer-view/test/HandleDragEnd.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handleDragEnd } from '../src/parts/HandleDragEnd/HandleDragEnd.ts'
+
+test('resets drag and pointer state', () => {
+  const state = {
+    ...createDefaultState(),
+    dropTargets: [1],
+    isPointerDown: true,
+    pointerDownIndex: 2,
+  }
+
+  expect(handleDragEnd(state)).toEqual({
+    ...state,
+    dropTargets: [],
+    isPointerDown: false,
+    pointerDownIndex: -1,
+  })
+})

--- a/packages/explorer-view/test/HandlePointerDown.test.ts
+++ b/packages/explorer-view/test/HandlePointerDown.test.ts
@@ -32,5 +32,9 @@ test('left click on item', () => {
     items: [{ depth: 0, name: 'test.txt', path: '/test.txt', selected: false, type: DirentType.File }],
   }
   const result = handlePointerDown(state, MouseEventType.LeftClick, 0, 0)
-  expect(result).toEqual(state)
+  expect(result).toEqual({
+    ...state,
+    isPointerDown: true,
+    pointerDownIndex: 0,
+  })
 })

--- a/packages/explorer-view/test/HandlePointerUp.test.ts
+++ b/packages/explorer-view/test/HandlePointerUp.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@jest/globals'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import { handlePointerUp } from '../src/parts/HandlePointerUp/HandlePointerUp.ts'
+
+test('resets pointer drag state', () => {
+  const state = {
+    ...createDefaultState(),
+    isPointerDown: true,
+    pointerDownIndex: 3,
+  }
+
+  expect(handlePointerUp(state)).toEqual({
+    ...state,
+    isPointerDown: false,
+    pointerDownIndex: -1,
+  })
+})
+
+test('returns the same state when pointer drag state is already reset', () => {
+  const state = createDefaultState()
+  expect(handlePointerUp(state)).toBe(state)
+})

--- a/packages/explorer-view/test/RenderDragData.test.ts
+++ b/packages/explorer-view/test/RenderDragData.test.ts
@@ -9,23 +9,27 @@ test('renderDragData - no items', () => {
   const newState: ExplorerState = {
     ...oldState,
     focusedIndex: 0,
+    isPointerDown: true,
     items: [],
+    pointerDownIndex: 0,
     uid: 123,
   }
   const result = renderDragData(oldState, newState)
   expect(result).toEqual(['Viewlet.setDragData', 123, expect.anything()])
 })
 
-test('renderDragData - selected and focused items', () => {
+test('renderDragData - selected and pointed items', () => {
   const oldState: ExplorerState = createDefaultState()
   const newState: ExplorerState = {
     ...oldState,
     focusedIndex: 1,
+    isPointerDown: true,
     items: [
       { depth: 1, icon: '', name: 'a.txt', path: '/workspace/a.txt', posInSet: 1, selected: true, setSize: 3, type: DirentType.File },
       { depth: 1, icon: '', name: 'b.txt', path: '/workspace/b.txt', posInSet: 2, selected: false, setSize: 3, type: DirentType.File },
       { depth: 1, icon: '', name: 'c.txt', path: 'file:///workspace/c.txt', posInSet: 3, selected: true, setSize: 3, type: DirentType.File },
     ],
+    pointerDownIndex: 1,
     uid: 123,
   }
   expect(renderDragData(oldState, newState)).toEqual([

--- a/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
+++ b/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@jest/globals'
+import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as Diff2 from '../src/parts/Diff2/Diff2.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
+import { handlePointerDown } from '../src/parts/HandlePointerDown/HandlePointerDown.ts'
+import { handlePointerUp } from '../src/parts/HandlePointerUp/HandlePointerUp.ts'
+import * as MouseEventType from '../src/parts/MouseEventType/MouseEventType.ts'
+import * as Render2 from '../src/parts/Render2/Render2.ts'
+
+test('pointer down renders drag data for the pointed explorer item', () => {
+  const uid = 42
+  const oldState: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [{ depth: 0, name: 'file.txt', path: '/workspace/file.txt', selected: false, type: DirentType.File }],
+    uid,
+  }
+  ExplorerStates.set(uid, oldState, oldState)
+
+  const newState = handlePointerDown(oldState, MouseEventType.LeftClick, 0, 0)
+  ExplorerStates.set(uid, oldState, newState)
+  const diffResult = Diff2.diff2(uid)
+  const commands = Render2.render2(uid, diffResult)
+
+  expect(commands).toEqual([
+    [
+      'Viewlet.setDragData',
+      uid,
+      {
+        items: [
+          { data: 'file:///workspace/file.txt', type: 'text/uri-list' },
+          { data: 'file:///workspace/file.txt', type: 'text/plain' },
+        ],
+        label: 'file.txt',
+      },
+    ],
+  ])
+})
+
+test('pointer up rearms drag data rendering for repeated drags', () => {
+  const uid = 43
+  const initialState: ExplorerState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [
+      { depth: 0, name: 'first.txt', path: '/workspace/first.txt', selected: false, type: DirentType.File },
+      { depth: 0, name: 'second.txt', path: '/workspace/second.txt', selected: false, type: DirentType.File },
+    ],
+    uid,
+  }
+  ExplorerStates.set(uid, initialState, initialState)
+
+  const pointerDownState = handlePointerDown(initialState, MouseEventType.LeftClick, 0, initialState.itemHeight)
+  ExplorerStates.set(uid, initialState, pointerDownState)
+  const firstCommands = Render2.render2(uid, Diff2.diff2(uid))
+
+  const pointerUpState = handlePointerUp(pointerDownState)
+  ExplorerStates.set(uid, pointerDownState, pointerUpState)
+  expect(Render2.render2(uid, Diff2.diff2(uid))).toEqual([])
+
+  const secondPointerDownState = handlePointerDown(pointerUpState, MouseEventType.LeftClick, 0, initialState.itemHeight)
+  ExplorerStates.set(uid, pointerUpState, secondPointerDownState)
+  const secondCommands = Render2.render2(uid, Diff2.diff2(uid))
+
+  const expectedCommand = [
+    'Viewlet.setDragData',
+    uid,
+    {
+      items: [
+        { data: 'file:///workspace/second.txt', type: 'text/uri-list' },
+        { data: 'file:///workspace/second.txt', type: 'text/plain' },
+      ],
+      label: 'second.txt',
+    },
+  ]
+  expect(firstCommands).toEqual([expectedCommand])
+  expect(secondCommands).toEqual([expectedCommand])
+})

--- a/packages/explorer-view/test/RenderEventListeners.test.ts
+++ b/packages/explorer-view/test/RenderEventListeners.test.ts
@@ -26,4 +26,8 @@ test('renderEventListeners', () => {
     name: 23,
     params: ['handleScrollBarCaptureLost'],
   })
+  expect(eventListeners).toContainEqual({
+    name: 25,
+    params: ['handlePointerUp'],
+  })
 })


### PR DESCRIPTION
Render explorer drag data when a draggable item receives pointer down so the command reaches renderer-process before drag start. Track the pointed item and reset pointer state after pointer-up or drag-end so repeated drags refresh the payload.