### PR TITLE
fix: clear explorer keyboard focus on blur

### DIFF
--- a/packages/e2e/src/viewlet.explorer-blur-clears-keyboard-focus.ts
+++ b/packages/e2e/src/viewlet.explorer-blur-clears-keyboard-focus.ts
@@ -1,0 +1,20 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'viewlet.explorer-blur-clears-keyboard-focus'
+
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, KeyBoard, Locator, Workspace }) => {
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await Workspace.setPath(tmpDir)
+  await Command.execute('Explorer.focus')
+  await Explorer.focusIndex(0)
+
+  const explorerItems = Locator('.Explorer .ListItems')
+  await expect(explorerItems).toBeFocused()
+
+  await Explorer.handleBlur()
+  await KeyBoard.press('Space')
+
+  const editorTab = Locator('.MainTab[title$="file.txt"]')
+  await expect(editorTab).toBeHidden()
+}

--- a/packages/explorer-view/src/parts/HandleBlur/HandleBlur.ts
+++ b/packages/explorer-view/src/parts/HandleBlur/HandleBlur.ts
@@ -1,4 +1,5 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as FocusId from '../FocusId/FocusId.ts'
 
 export const handleBlur = async (state: ExplorerState): Promise<ExplorerState> => {
   // TODO when blur event occurs because of context menu, focused index should stay the same
@@ -12,6 +13,7 @@ export const handleBlur = async (state: ExplorerState): Promise<ExplorerState> =
   })
   return {
     ...state,
+    focus: FocusId.None,
     focused: false,
     items: newItems,
   }

--- a/packages/explorer-view/test/HandleBlur.test.ts
+++ b/packages/explorer-view/test/HandleBlur.test.ts
@@ -4,12 +4,17 @@ import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import * as ExplorerEditingType from '../src/parts/ExplorerEditingType/ExplorerEditingType.ts'
+import * as FocusId from '../src/parts/FocusId/FocusId.ts'
 import { handleBlur } from '../src/parts/HandleBlur/HandleBlur.ts'
 
-test('handleBlur - when not editing, sets focused to false', async () => {
-  const state: ExplorerState = createDefaultState()
+test('handleBlur - when not editing, clears visual and keyboard focus', async () => {
+  const state: ExplorerState = {
+    ...createDefaultState(),
+    focus: FocusId.List,
+  }
   const newState = await handleBlur(state)
   expect(newState.focused).toBe(false)
+  expect(newState.focus).toBe(FocusId.None)
 })
 
 test.skip('handleBlur - when editing, keeps state unchanged', async () => {


### PR DESCRIPTION
Clear the Explorer keyboard focus context when its tree loses DOM focus so delayed blur routing cannot override the integrated terminal. Add unit and browser regression coverage for Space after Explorer blur.