### PR TITLE
fix: paste native files into explorer

### DIFF
--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -53,6 +53,7 @@ import * as HandleInputBlur from '../HandleInputBlur/HandleInputBlur.ts'
 import * as HandleInputClick from '../HandleInputClick/HandleInputClick.ts'
 import * as HandleInputKeyDown from '../HandleInputKeyDown/HandleInputKeyDown.ts'
 import * as HandleKeyDown from '../HandleKeyDown/HandleKeyDown.ts'
+import * as HandleNativePaste from '../HandleNativePaste/HandleNativePaste.ts'
 import * as HandlePaste from '../HandlePaste/HandlePaste.ts'
 import * as HandlePointerDown from '../HandlePointerDown/HandlePointerDown.ts'
 import * as HandlePointerUp from '../HandlePointerUp/HandlePointerUp.ts'
@@ -145,6 +146,7 @@ export const commandMap = {
   'Explorer.handleInputClick': WrapCommand.wrapListItemCommand(HandleInputClick.handleInputClick),
   'Explorer.handleInputKeyDown': WrapCommand.wrapListItemCommand(HandleInputKeyDown.handleInputKeyDown),
   'Explorer.handleKeyDown': WrapCommand.wrapListItemCommand(HandleKeyDown.handleKeyDown),
+  'Explorer.handleNativePaste': WrapCommand.wrapListItemCommand(HandleNativePaste.handleNativePaste),
   'Explorer.handlePaste': WrapCommand.wrapListItemCommand(HandlePaste.handlePaste),
   'Explorer.handlePointerDown': WrapCommand.wrapListItemCommand(HandlePointerDown.handlePointerDown),
   'Explorer.handlePointerUp': WrapCommand.wrapListItemCommand(HandlePointerUp.handlePointerUp),

--- a/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
+++ b/packages/explorer-view/src/parts/DomEventListenerFunctions/DomEventListenerFunctions.ts
@@ -14,6 +14,7 @@ export const HandleInputClick = 9
 export const HandleKeyDown = 21
 export const HandleListBlur = 11
 export const HandleListFocus = 12
+export const HandleNativePaste = 26
 export const HandlePointerDown = 14
 export const HandlePointerUp = 25
 export const HandleScrollBarMove = 22

--- a/packages/explorer-view/src/parts/GetKeyBindings/GetKeyBindings.ts
+++ b/packages/explorer-view/src/parts/GetKeyBindings/GetKeyBindings.ts
@@ -60,11 +60,6 @@ export const getKeyBindings = (): readonly KeyBinding[] => {
       when: WhenExpression.FocusExplorer,
     },
     {
-      command: 'Explorer.handlePaste',
-      key: KeyModifier.CtrlCmd | KeyCode.KeyV,
-      when: WhenExpression.FocusExplorer,
-    },
-    {
       command: 'Explorer.handleCopy',
       key: KeyModifier.CtrlCmd | KeyCode.KeyC,
       when: WhenExpression.FocusExplorer,

--- a/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
+++ b/packages/explorer-view/src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts
@@ -47,6 +47,7 @@ export const getListItemsVirtualDom = (
       onDragStart: DomEventListenerFunctions.HandleDragStart,
       onDrop: DomEventListenerFunctions.HandleDrop,
       onFocus: DomEventListenerFunctions.HandleListFocus,
+      onPaste: DomEventListenerFunctions.HandleNativePaste,
       onPointerDown: DomEventListenerFunctions.HandlePointerDown,
       onPointerUp: DomEventListenerFunctions.HandlePointerUp,
       onWheel: DomEventListenerFunctions.HandleWheel,

--- a/packages/explorer-view/src/parts/HandleNativePaste/HandleNativePaste.ts
+++ b/packages/explorer-view/src/parts/HandleNativePaste/HandleNativePaste.ts
@@ -1,0 +1,36 @@
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import { getDropHandler } from '../GetDropHandler/GetDropHandler.ts'
+import { getDroppedItems } from '../GetDroppedItems/GetDroppedItems.ts'
+import * as HandlePaste from '../HandlePaste/HandlePaste.ts'
+import * as HandlePasteCopy from '../HandlePasteCopy/HandlePasteCopy.ts'
+import * as PlatformType from '../PlatformType/PlatformType.ts'
+import { VError } from '../VError/VError.ts'
+
+export const handleNativePaste = async (state: ExplorerState, itemIds: readonly number[]): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
+  if (itemIds.length === 0) {
+    return HandlePaste.handlePaste(state)
+  }
+  try {
+    const isElectron = state.platform === PlatformType.Electron
+    const { fileHandles, paths } = await getDroppedItems(itemIds, isElectron)
+    if (isElectron) {
+      const nativePaths = paths.filter(Boolean)
+      if (nativePaths.length === 0) {
+        return HandlePaste.handlePaste(state)
+      }
+      return HandlePasteCopy.handlePasteCopy(state, {
+        files: nativePaths,
+        source: 'gnomeCopiedFiles',
+        type: 'copy',
+      })
+    }
+    const index = state.focusedIndex
+    const handleDrop = getDropHandler(index)
+    return handleDrop(state, fileHandles, [], paths, index)
+  } catch (error) {
+    throw new VError(error, 'Failed to paste native files')
+  }
+}

--- a/packages/explorer-view/src/parts/HandleNativePaste/HandleNativePaste.ts
+++ b/packages/explorer-view/src/parts/HandleNativePaste/HandleNativePaste.ts
@@ -7,14 +7,15 @@ import * as PlatformType from '../PlatformType/PlatformType.ts'
 import { VError } from '../VError/VError.ts'
 
 export const handleNativePaste = async (state: ExplorerState, itemIds: readonly number[]): Promise<ExplorerState> => {
-  if (state.isReadonly) {
+  const { focusedIndex, isReadonly, platform } = state
+  if (isReadonly) {
     return state
   }
   if (itemIds.length === 0) {
     return HandlePaste.handlePaste(state)
   }
   try {
-    const isElectron = state.platform === PlatformType.Electron
+    const isElectron = platform === PlatformType.Electron
     const { fileHandles, paths } = await getDroppedItems(itemIds, isElectron)
     if (isElectron) {
       const nativePaths = paths.filter(Boolean)
@@ -27,9 +28,8 @@ export const handleNativePaste = async (state: ExplorerState, itemIds: readonly 
         type: 'copy',
       })
     }
-    const index = state.focusedIndex
-    const handleDrop = getDropHandler(index)
-    return handleDrop(state, fileHandles, [], paths, index)
+    const handleDrop = getDropHandler(focusedIndex)
+    return handleDrop(state, fileHandles, [], paths, focusedIndex)
   } catch (error) {
     throw new VError(error, 'Failed to paste native files')
   }

--- a/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -99,6 +99,11 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
       preventDefault: true,
     },
     {
+      name: DomEventListenersFunctions.HandleNativePaste,
+      params: ['handleNativePaste', 'event.clipboardData.files2'],
+      preventDefault: true,
+    },
+    {
       name: DomEventListenersFunctions.HandleDragLeave,
       params: ['handleDragLeave'],
     },

--- a/packages/explorer-view/test/GetKeyBindings.test.ts
+++ b/packages/explorer-view/test/GetKeyBindings.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 import { WhenExpression } from '@lvce-editor/constants'
-import { KeyCode } from '@lvce-editor/virtual-dom-worker'
+import { KeyCode, KeyModifier } from '@lvce-editor/virtual-dom-worker'
 import { getKeyBindings } from '../src/parts/GetKeyBindings/GetKeyBindings.ts'
 
 test('getKeyBindings', () => {
@@ -32,4 +32,13 @@ test('registers Space to open the focused item without moving focus', () => {
       when: WhenExpression.FocusExplorer,
     },
   ])
+})
+
+test('allows the browser to dispatch native paste events', () => {
+  const keyBindings = getKeyBindings()
+  const pasteKeyBindings = keyBindings.filter(
+    ({ key, when }) => key === (KeyModifier.CtrlCmd | KeyCode.KeyV) && when === WhenExpression.FocusExplorer,
+  )
+
+  expect(pasteKeyBindings).toEqual([])
 })

--- a/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
+++ b/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
@@ -1,11 +1,12 @@
 import { expect, test } from '@jest/globals'
 import { getListItemsVirtualDom } from '../src/parts/GetListItemsVirtualDom/GetListItemsVirtualDom.ts'
 
-test('registers pointer lifecycle handlers on the explorer tree', () => {
+test('registers pointer and native paste handlers on the explorer tree', () => {
   const [tree] = getListItemsVirtualDom([], -1, false, [])
 
   expect(tree).toMatchObject({
     onPointerDown: 14,
     onPointerUp: 25,
+    onPaste: 26,
   })
 })

--- a/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
+++ b/packages/explorer-view/test/GetListItemsVirtualDom.test.ts
@@ -5,8 +5,8 @@ test('registers pointer and native paste handlers on the explorer tree', () => {
   const [tree] = getListItemsVirtualDom([], -1, false, [])
 
   expect(tree).toMatchObject({
+    onPaste: 26,
     onPointerDown: 14,
     onPointerUp: 25,
-    onPaste: 26,
   })
 })

--- a/packages/explorer-view/test/HandleNativePaste.test.ts
+++ b/packages/explorer-view/test/HandleNativePaste.test.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@jest/globals'
+import { DragAndDropWorker, RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import { handleNativePaste } from '../src/parts/HandleNativePaste/HandleNativePaste.ts'
+import * as NativeFileTypes from '../src/parts/NativeFileTypes/NativeFileTypes.ts'
+import * as PlatformType from '../src/parts/PlatformType/PlatformType.ts'
+
+test('copies a native Electron file into the focused workspace folder', async () => {
+  using dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.getDroppedItems'() {
+      return {
+        files: [{ handle: undefined, kind: 'file', name: 'Main.elm', path: '/home/test/Main.elm', uri: 'file:///home/test/Main.elm' }],
+        strings: [],
+        uris: ['file:///home/test/Main.elm'],
+      }
+    },
+  })
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'FileSystem.copy'() {},
+    'FileSystem.readDirWithFileTypes'(path: string) {
+      if (path === '/workspace/src') {
+        return []
+      }
+      return [{ name: 'src', type: DirentType.Directory }]
+    },
+    'IconTheme.getIcons'() {
+      return ['']
+    },
+    'Preferences.get'() {
+      return false
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [{ depth: 0, name: 'src', path: '/workspace/src', selected: false, type: DirentType.Directory }],
+    platform: PlatformType.Electron,
+    root: '/workspace',
+  }
+
+  await handleNativePaste(state, [41])
+
+  expect(dragRpc.invocations).toEqual([['DragAndDrop.getDroppedItems', [41], true]])
+  expect(rendererRpc.invocations).toEqual([
+    ['FileSystem.readDirWithFileTypes', '/workspace/src'],
+    ['FileSystem.copy', '/home/test/Main.elm', '/workspace/src/Main.elm'],
+    ['FileSystem.readDirWithFileTypes', '/workspace'],
+  ])
+})
+
+test('falls back to the internal clipboard when the paste event has no files', async () => {
+  using rendererRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.readNativeFiles'() {
+      return { files: [], type: NativeFileTypes.None }
+    },
+  })
+  const state = createDefaultState()
+
+  const result = await handleNativePaste(state, [])
+
+  expect(result).toBe(state)
+  expect(rendererRpc.invocations).toEqual([['ClipBoard.readNativeFiles']])
+})
+
+test('does not paste native files into a readonly workspace', async () => {
+  const state = { ...createDefaultState(), isReadonly: true }
+
+  await expect(handleNativePaste(state, [41])).resolves.toBe(state)
+})
+
+test('wraps native clipboard resolution errors', async () => {
+  using _dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.getDroppedItems'() {
+      throw new Error('native path unavailable')
+    },
+  })
+  const state = { ...createDefaultState(), platform: PlatformType.Electron }
+
+  await expect(handleNativePaste(state, [41])).rejects.toThrow('Failed to paste native files: native path unavailable')
+})

--- a/packages/explorer-view/test/RenderEventListeners.test.ts
+++ b/packages/explorer-view/test/RenderEventListeners.test.ts
@@ -30,4 +30,9 @@ test('renderEventListeners', () => {
     name: 25,
     params: ['handlePointerUp'],
   })
+  expect(eventListeners).toContainEqual({
+    name: 26,
+    params: ['handleNativePaste', 'event.clipboardData.files2'],
+    preventDefault: true,
+  })
 })


### PR DESCRIPTION
Handle native clipboard file events in Explorer and import copied filesystem files into the focused workspace folder while preserving internal copy/paste behavior.