### PR TITLE
fix: move explorer items on drop

### DIFF
--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 605_000
+const threshold = 607_000
 
 const instantiations = 200_000
 

--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 607_000
+const threshold = 608_000
 
 const instantiations = 200_000
 

--- a/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
@@ -2,28 +2,19 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-drag-file-into-folder'
 
-export const skip = 1
-
-export const test: Test = async ({ Explorer, FileSystem, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
-  await FileSystem.mkdir(`${tmpDir}/new`)
-  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'content')
+  await FileSystem.mkdir(`${tmpDir}/src`)
+  await FileSystem.writeFile(`${tmpDir}/Main.elm`, 'module Main exposing (main)')
   await Workspace.setPath(tmpDir)
-  await Explorer.focusIndex(1)
-  await Explorer.handleDragOverIndex(1)
 
   // act
+  await Explorer.handleDragOverIndex(0)
+  await Explorer.handleDropIndex([], [], [`${tmpDir}/Main.elm`], 0)
 
-  // const opfsRoot = await navigator.storage.getDirectory()
-  // const fileHandle = await opfsRoot.getFileHandle('my first file', {
-  //   create: true,
-  // })
-  // console.log({ fileHandle })
-  // const fileHandles = [fileHandle]
-  // const files = []
-  // const paths = []
-  // const index = 0
-  // await Explorer.handleDropIndex(fileHandles, files, paths, index)
-  // TODO drop file into folder and verify it is moved
+  // assert
+  await expect(Locator(`.TreeItem[title="${tmpDir}/Main.elm"]`)).toBeHidden()
+  await expect(Locator(`.TreeItem[title="${tmpDir}/src/Main.elm"]`)).toBeVisible()
+  await FileSystem.shouldHaveFile(`${tmpDir}/src/Main.elm`, 'module Main exposing (main)')
 }

--- a/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
+++ b/packages/e2e/src/viewlet.explorer-drag-file-into-folder.ts
@@ -14,7 +14,9 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.handleDropIndex([], [], [`${tmpDir}/Main.elm`], 0)
 
   // assert
-  await expect(Locator(`.TreeItem[title="${tmpDir}/Main.elm"]`)).toBeHidden()
-  await expect(Locator(`.TreeItem[title="${tmpDir}/src/Main.elm"]`)).toBeVisible()
+  const originalFile = Locator(`.TreeItem[title="${tmpDir}/Main.elm"]`)
+  const movedFile = Locator(`.TreeItem[title="${tmpDir}/src/Main.elm"]`)
+  await expect(originalFile).toBeHidden()
+  await expect(movedFile).toBeVisible()
   await FileSystem.shouldHaveFile(`${tmpDir}/src/Main.elm`, 'module Main exposing (main)')
 }

--- a/packages/explorer-view/src/parts/ExplorerStrings/ExplorerStrings.ts
+++ b/packages/explorer-view/src/parts/ExplorerStrings/ExplorerStrings.ts
@@ -125,6 +125,12 @@ export const cannotCopyFolderIntoSubfolderOfItself = (folderName: string): strin
   })
 }
 
+export const cannotMoveFolderIntoSubfolderOfItself = (folderName: string): string => {
+  return I18nString.i18nString(UiStrings.CannotMoveFolderIntoSubfolderOfItself, {
+    PH1: folderName,
+  })
+}
+
 export const theNameIsNotValid = (): string => {
   return I18nString.i18nString(UiStrings.TheNameIsNotValid)
 }

--- a/packages/explorer-view/src/parts/GetDragData/GetDragData.ts
+++ b/packages/explorer-view/src/parts/GetDragData/GetDragData.ts
@@ -1,11 +1,5 @@
+import { ensureUri } from '../EnsureUris/EnsureUris.ts'
 import { getDragLabel } from '../GetDragLabel/GetDragLabel.ts'
-
-const toUri = (path: string): string => {
-  if (path.startsWith('file://')) {
-    return path
-  }
-  return 'file://' + path
-}
 
 interface DragInfoItem {
   readonly data: string
@@ -18,7 +12,7 @@ export interface IDragInfoNew {
 }
 
 export const getDragData = (urls: readonly string[]): IDragInfoNew => {
-  const data = urls.map(toUri).join('\n')
+  const data = urls.map(ensureUri).join('\n')
   const dragData: readonly DragInfoItem[] = [
     {
       data,

--- a/packages/explorer-view/src/parts/GetDroppedItems/GetDroppedItems.ts
+++ b/packages/explorer-view/src/parts/GetDroppedItems/GetDroppedItems.ts
@@ -4,6 +4,7 @@ import type { DroppedArgs } from '../UploadFileSystemHandles/UploadFileSystemHan
 export interface ExplorerDroppedItems {
   readonly fileHandles: DroppedArgs
   readonly paths: readonly string[]
+  readonly uris: readonly string[]
 }
 
 export const getDroppedItems = async (itemIds: readonly number[], isElectron: boolean): Promise<ExplorerDroppedItems> => {
@@ -11,5 +12,5 @@ export const getDroppedItems = async (itemIds: readonly number[], isElectron: bo
   const files = isElectron ? result.files : result.files.filter((file) => file.handle)
   const fileHandles = files.map((file) => file.handle || ({ kind: file.kind, name: file.name } as FileSystemHandle))
   const paths = files.map((file) => file.path)
-  return { fileHandles, paths }
+  return { fileHandles, paths, uris: result.uris }
 }

--- a/packages/explorer-view/src/parts/GetInternalDragPaths/GetInternalDragPaths.ts
+++ b/packages/explorer-view/src/parts/GetInternalDragPaths/GetInternalDragPaths.ts
@@ -1,0 +1,18 @@
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
+import { ensureUri } from '../EnsureUris/EnsureUris.ts'
+
+export const getInternalDragPaths = (items: readonly ExplorerItem[], uris: readonly string[]): readonly string[] => {
+  if (uris.length === 0) {
+    return []
+  }
+  const pathByUri = new Map(items.map((item) => [ensureUri(item.path), item.path]))
+  const paths: string[] = []
+  for (const uri of uris) {
+    const path = pathByUri.get(uri)
+    if (path === undefined) {
+      return []
+    }
+    paths.push(path)
+  }
+  return paths
+}

--- a/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
+++ b/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
@@ -1,8 +1,8 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import { getDropHandler } from '../GetDropHandler/GetDropHandler.ts'
 import { getDroppedItems } from '../GetDroppedItems/GetDroppedItems.ts'
-import { getInternalDragPaths } from '../GetInternalDragPaths/GetInternalDragPaths.ts'
 import * as GetIndexFromPosition from '../GetIndexFromPosition/GetIndexFromPosition.ts'
+import { getInternalDragPaths } from '../GetInternalDragPaths/GetInternalDragPaths.ts'
 import * as PlatformType from '../PlatformType/PlatformType.ts'
 import { VError } from '../VError/VError.ts'
 

--- a/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
+++ b/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
@@ -1,6 +1,7 @@
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import { getDropHandler } from '../GetDropHandler/GetDropHandler.ts'
 import { getDroppedItems } from '../GetDroppedItems/GetDroppedItems.ts'
+import { getInternalDragPaths } from '../GetInternalDragPaths/GetInternalDragPaths.ts'
 import * as GetIndexFromPosition from '../GetIndexFromPosition/GetIndexFromPosition.ts'
 import * as PlatformType from '../PlatformType/PlatformType.ts'
 import { VError } from '../VError/VError.ts'
@@ -11,10 +12,12 @@ export const handleDrop = async (state: ExplorerState, x: number, y: number, fil
   }
   try {
     const isElectron = state.platform === PlatformType.Electron
-    const { fileHandles, paths } = await getDroppedItems(fileIds, isElectron)
+    const { fileHandles, paths, uris } = await getDroppedItems(fileIds, isElectron)
+    const internalPaths = getInternalDragPaths(state.items, uris)
+    const droppedPaths = internalPaths.length > 0 ? internalPaths : paths
     const index = GetIndexFromPosition.getIndexFromPosition(state, x, y)
     const fn = getDropHandler(index)
-    const result = await fn(state, fileHandles, [], paths, index)
+    const result = await fn(state, fileHandles, [], droppedPaths, index)
     return result
   } catch (error) {
     throw new VError(error, 'Failed to drop files')

--- a/packages/explorer-view/src/parts/HandleDropIndex/HandleDropIndex.ts
+++ b/packages/explorer-view/src/parts/HandleDropIndex/HandleDropIndex.ts
@@ -5,6 +5,7 @@ import * as DirentType from '../DirentType/DirentType.ts'
 import * as GetChildDirents from '../GetChildDirents/GetChildDirents.ts'
 import * as GetParentStartIndex from '../GetParentStartIndex/GetParentStartIndex.ts'
 import * as HandleDropRoot from '../HandleDropRoot/HandleDropRoot.ts'
+import { handleInternalDrop } from '../HandleInternalDrop/HandleInternalDrop.ts'
 import { uploadFileSystemHandles } from '../UploadFileSystemHandles/UploadFileSystemHandles.ts'
 
 const getEndIndex = (items: readonly ExplorerItem[], index: number, dirent: ExplorerItem): number => {
@@ -75,6 +76,9 @@ export const handleDropIndex = async (
 ): Promise<ExplorerState> => {
   if (state.isReadonly) {
     return state
+  }
+  if (fileHandles.length === 0 && paths.length > 0) {
+    return handleInternalDrop(state, paths, index)
   }
   const { items } = state
   const dirent = items[index]

--- a/packages/explorer-view/src/parts/HandleDropRoot/HandleDropRoot.ts
+++ b/packages/explorer-view/src/parts/HandleDropRoot/HandleDropRoot.ts
@@ -2,6 +2,7 @@ import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import type { DroppedArgs } from '../UploadFileSystemHandles/UploadFileSystemHandles.ts'
 import * as HandleDropRootDefault from '../HandleDropRootDefault/HandleDropRootDefault.ts'
 import * as HandleDropRootElectron from '../HandleDropRootElectron/HandleDropRootElectron.ts'
+import { handleInternalDrop } from '../HandleInternalDrop/HandleInternalDrop.ts'
 import * as PlatformType from '../PlatformType/PlatformType.ts'
 
 interface DropHandler {
@@ -23,6 +24,9 @@ export const handleDropRoot = async (
 ): Promise<ExplorerState> => {
   if (state.isReadonly && state.root !== '') {
     return state
+  }
+  if (fileHandles.length === 0 && paths.length > 0) {
+    return handleInternalDrop(state, paths, -1)
   }
   const isElectron = state.platform === PlatformType.Electron
   const fn = getModule(isElectron)

--- a/packages/explorer-view/src/parts/HandleInternalDrop/HandleInternalDrop.ts
+++ b/packages/explorer-view/src/parts/HandleInternalDrop/HandleInternalDrop.ts
@@ -11,8 +11,10 @@ interface MoveOperation {
   readonly path: string
 }
 
+const directoryTypes: readonly number[] = [DirentType.Directory, DirentType.DirectoryExpanded, DirentType.DirectoryExpanding]
+
 const isDirectory = (item: ExplorerItem): boolean => {
-  return item.type === DirentType.Directory || item.type === DirentType.DirectoryExpanded || item.type === DirentType.DirectoryExpanding
+  return directoryTypes.includes(item.type)
 }
 
 const isDescendant = (path: string, parentPath: string, pathSeparator: string): boolean => {
@@ -47,7 +49,7 @@ const getTargetFolder = (state: ExplorerState, index: number): string => {
 
 const getTopLevelSourcePaths = (sourcePaths: readonly string[], pathSeparator: string): readonly string[] => {
   const uniquePaths = [...new Set(sourcePaths)]
-  return uniquePaths.filter((path) => !uniquePaths.some((otherPath) => otherPath !== path && isDescendant(path, otherPath, pathSeparator)))
+  return uniquePaths.filter((path) => uniquePaths.every((otherPath) => otherPath === path || !isDescendant(path, otherPath, pathSeparator)))
 }
 
 const getMoveOperations = (state: ExplorerState, sourcePaths: readonly string[], targetFolder: string): readonly MoveOperation[] => {
@@ -90,7 +92,8 @@ const expandTargetFolder = (items: readonly ExplorerItem[], targetFolder: string
 }
 
 export const handleInternalDrop = async (state: ExplorerState, sourcePaths: readonly string[], index: number): Promise<ExplorerState> => {
-  if (state.isReadonly) {
+  const { isReadonly, items } = state
+  if (isReadonly) {
     return state
   }
   const targetFolder = getTargetFolder(state, index)
@@ -104,8 +107,8 @@ export const handleInternalDrop = async (state: ExplorerState, sourcePaths: read
   for (const operation of operations) {
     await FileSystem.rename(operation.from, operation.path)
   }
-  const items = expandTargetFolder(state.items, targetFolder)
-  const updated = await Refresh.refresh({ ...state, items })
+  const expandedItems = expandTargetFolder(items, targetFolder)
+  const updated = await Refresh.refresh({ ...state, items: expandedItems })
   return {
     ...updated,
     dropTargets: [],

--- a/packages/explorer-view/src/parts/HandleInternalDrop/HandleInternalDrop.ts
+++ b/packages/explorer-view/src/parts/HandleInternalDrop/HandleInternalDrop.ts
@@ -1,0 +1,113 @@
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
+import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
+import * as DirentType from '../DirentType/DirentType.ts'
+import * as ExplorerStrings from '../ExplorerStrings/ExplorerStrings.ts'
+import * as FileSystem from '../FileSystem/FileSystem.ts'
+import * as Path from '../Path/Path.ts'
+import * as Refresh from '../Refresh/Refresh.ts'
+
+interface MoveOperation {
+  readonly from: string
+  readonly path: string
+}
+
+const isDirectory = (item: ExplorerItem): boolean => {
+  return item.type === DirentType.Directory || item.type === DirentType.DirectoryExpanded || item.type === DirentType.DirectoryExpanding
+}
+
+const isDescendant = (path: string, parentPath: string, pathSeparator: string): boolean => {
+  const prefix = parentPath.endsWith(pathSeparator) ? parentPath : `${parentPath}${pathSeparator}`
+  return path.startsWith(prefix)
+}
+
+const join = (parentPath: string, name: string, pathSeparator: string): string => {
+  if (parentPath.endsWith(pathSeparator)) {
+    return `${parentPath}${name}`
+  }
+  return `${parentPath}${pathSeparator}${name}`
+}
+
+const getTargetFolder = (state: ExplorerState, index: number): string => {
+  const { items, pathSeparator, root } = state
+  if (index === -1) {
+    return root
+  }
+  const item = items[index]
+  if (!item) {
+    throw new Error('Drop target does not exist')
+  }
+  if (isDirectory(item)) {
+    return item.path
+  }
+  if (item.type === DirentType.File) {
+    return Path.dirname(pathSeparator, item.path)
+  }
+  throw new Error('Drop target is not a file or folder')
+}
+
+const getTopLevelSourcePaths = (sourcePaths: readonly string[], pathSeparator: string): readonly string[] => {
+  const uniquePaths = [...new Set(sourcePaths)]
+  return uniquePaths.filter((path) => !uniquePaths.some((otherPath) => otherPath !== path && isDescendant(path, otherPath, pathSeparator)))
+}
+
+const getMoveOperations = (state: ExplorerState, sourcePaths: readonly string[], targetFolder: string): readonly MoveOperation[] => {
+  const { items, pathSeparator } = state
+  const itemByPath = new Map(items.map((item) => [item.path, item]))
+  const existingPaths = new Set(itemByPath.keys())
+  const destinationPaths = new Set<string>()
+  const operations: MoveOperation[] = []
+  for (const sourcePath of getTopLevelSourcePaths(sourcePaths, pathSeparator)) {
+    const sourceItem = itemByPath.get(sourcePath)
+    if (!sourceItem) {
+      throw new Error(`Dragged item no longer exists: ${sourcePath}`)
+    }
+    if (sourcePath === targetFolder) {
+      continue
+    }
+    if (isDirectory(sourceItem) && isDescendant(targetFolder, sourcePath, pathSeparator)) {
+      throw new Error(ExplorerStrings.cannotMoveFolderIntoSubfolderOfItself(sourceItem.name))
+    }
+    const destinationPath = join(targetFolder, sourceItem.name, pathSeparator)
+    if (destinationPath === sourcePath) {
+      continue
+    }
+    if (destinationPaths.has(destinationPath) || existingPaths.has(destinationPath)) {
+      throw new Error(ExplorerStrings.fileOrFolderAlreadyExists(sourceItem.name))
+    }
+    destinationPaths.add(destinationPath)
+    operations.push({ from: sourcePath, path: destinationPath })
+  }
+  return operations
+}
+
+const expandTargetFolder = (items: readonly ExplorerItem[], targetFolder: string): readonly ExplorerItem[] => {
+  return items.map((item) => {
+    if (item.path === targetFolder && item.type === DirentType.Directory) {
+      return { ...item, type: DirentType.DirectoryExpanded }
+    }
+    return item
+  })
+}
+
+export const handleInternalDrop = async (state: ExplorerState, sourcePaths: readonly string[], index: number): Promise<ExplorerState> => {
+  if (state.isReadonly) {
+    return state
+  }
+  const targetFolder = getTargetFolder(state, index)
+  const operations = getMoveOperations(state, sourcePaths, targetFolder)
+  if (operations.length === 0) {
+    return {
+      ...state,
+      dropTargets: [],
+    }
+  }
+  for (const operation of operations) {
+    await FileSystem.rename(operation.from, operation.path)
+  }
+  const items = expandTargetFolder(state.items, targetFolder)
+  const updated = await Refresh.refresh({ ...state, items })
+  return {
+    ...updated,
+    dropTargets: [],
+  }
+}

--- a/packages/explorer-view/src/parts/UiStrings/UiStrings.ts
+++ b/packages/explorer-view/src/parts/UiStrings/UiStrings.ts
@@ -1,5 +1,6 @@
 export const CollapseAllFoldersInExplorer = 'Collapse All Folders in Explorer'
 export const CannotCopyFolderIntoSubfolderOfItself = 'Cannot copy folder {PH1} into a subfolder of itself'
+export const CannotMoveFolderIntoSubfolderOfItself = 'Cannot move folder {PH1} into a subfolder of itself'
 export const Copy = 'Copy'
 export const CopyPath = 'Copy Path'
 export const CopyRelativePath = 'Copy Relative Path'

--- a/packages/explorer-view/test/ExplorerStrings.test.ts
+++ b/packages/explorer-view/test/ExplorerStrings.test.ts
@@ -102,3 +102,7 @@ test('theNameIsNotValid', () => {
 test('leadingOrTrailingWhitespaceDetected', () => {
   expect(ExplorerStrings.leadingOrTrailingWhitespaceDetected()).toBe('Leading or trailing whitespace detected in file or folder name.')
 })
+
+test('cannotMoveFolderIntoSubfolderOfItself', () => {
+  expect(ExplorerStrings.cannotMoveFolderIntoSubfolderOfItself('src')).toBe('Cannot move folder src into a subfolder of itself')
+})

--- a/packages/explorer-view/test/GetDragData.test.ts
+++ b/packages/explorer-view/test/GetDragData.test.ts
@@ -24,3 +24,9 @@ test('getDragData - empty', () => {
   expect(result.items[1]).toEqual({ data: '', type: 'text/plain' })
   expect(result.label).toBe('0')
 })
+
+test('getDragData - preserves non-file workspace uri', () => {
+  const result = getDragData(['memfs:///workspace/Main.elm'])
+
+  expect(result.items[0]).toEqual({ data: 'memfs:///workspace/Main.elm', type: 'text/uri-list' })
+})

--- a/packages/explorer-view/test/GetDroppedItems.test.ts
+++ b/packages/explorer-view/test/GetDroppedItems.test.ts
@@ -17,7 +17,7 @@ test('normalizes worker files for browser explorer handling', async () => {
     },
   })
 
-  expect(await getDroppedItems([1, 2], false)).toEqual({ fileHandles: [handle], paths: [''] })
+  expect(await getDroppedItems([1, 2], false)).toEqual({ fileHandles: [handle], paths: [''], uris: ['html:///notes.txt'] })
   expect(dragRpc.invocations).toEqual([['DragAndDrop.getDroppedItems', [1, 2], false]])
 })
 
@@ -35,5 +35,6 @@ test('keeps path-only electron files', async () => {
   expect(await getDroppedItems([1], true)).toEqual({
     fileHandles: [{ kind: 'file', name: 'legacy.txt' }],
     paths: ['/tmp/legacy.txt'],
+    uris: ['file:///tmp/legacy.txt'],
   })
 })

--- a/packages/explorer-view/test/GetInternalDragPaths.test.ts
+++ b/packages/explorer-view/test/GetInternalDragPaths.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@jest/globals'
+import type { ExplorerItem } from '../src/parts/ExplorerItem/ExplorerItem.ts'
+import { getInternalDragPaths } from '../src/parts/GetInternalDragPaths/GetInternalDragPaths.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+
+const items: readonly ExplorerItem[] = [
+  { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },
+  { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.Directory },
+]
+
+test('returns Explorer paths matching retained drag uris', () => {
+  expect(getInternalDragPaths(items, ['file:///workspace/Main.elm'])).toEqual(['/workspace/Main.elm'])
+})
+
+test('preserves non-file workspace uris', () => {
+  const memoryItems: readonly ExplorerItem[] = [
+    { depth: 1, name: 'Main.elm', path: 'memfs:///workspace/Main.elm', selected: false, type: DirentType.File },
+  ]
+
+  expect(getInternalDragPaths(memoryItems, ['memfs:///workspace/Main.elm'])).toEqual(['memfs:///workspace/Main.elm'])
+})
+
+test('rejects a partially external uri list', () => {
+  expect(getInternalDragPaths(items, ['file:///workspace/Main.elm', 'file:///tmp/external.txt'])).toEqual([])
+})

--- a/packages/explorer-view/test/GetInternalDragPaths.test.ts
+++ b/packages/explorer-view/test/GetInternalDragPaths.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@jest/globals'
 import type { ExplorerItem } from '../src/parts/ExplorerItem/ExplorerItem.ts'
-import { getInternalDragPaths } from '../src/parts/GetInternalDragPaths/GetInternalDragPaths.ts'
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import { getInternalDragPaths } from '../src/parts/GetInternalDragPaths/GetInternalDragPaths.ts'
 
 const items: readonly ExplorerItem[] = [
   { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },

--- a/packages/explorer-view/test/HandleDrop.test.ts
+++ b/packages/explorer-view/test/HandleDrop.test.ts
@@ -50,10 +50,7 @@ test('handleDrop - moves an internal Explorer file into the drop target folder',
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readDirWithFileTypes'(path: string) {
       if (path === '/workspace') {
-        return [
-          { name: 'src', type: DirentType.Directory },
-          ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }]),
-        ]
+        return [{ name: 'src', type: DirentType.Directory }, ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }])]
       }
       return moved ? [{ name: 'Main.elm', type: DirentType.File }] : []
     },

--- a/packages/explorer-view/test/HandleDrop.test.ts
+++ b/packages/explorer-view/test/HandleDrop.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@jest/globals'
 import { DragAndDropWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import { handleDrop } from '../src/parts/HandleDrop/HandleDrop.ts'
 
 test('handleDrop - successful drop', async () => {
@@ -37,4 +38,64 @@ test('handleDrop - error case', async () => {
 
   await expect(handleDrop(state, 0, 0, [1])).rejects.toThrow(new Error('Failed to drop files: test error'))
   expect(dragRpc.invocations).toEqual([['DragAndDrop.getDroppedItems', [1], false]])
+})
+
+test('handleDrop - moves an internal Explorer file into the drop target folder', async () => {
+  let moved = false
+  using dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.getDroppedItems'() {
+      return { files: [], strings: [], uris: ['file:///workspace/Main.elm'] }
+    },
+  })
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readDirWithFileTypes'(path: string) {
+      if (path === '/workspace') {
+        return [
+          { name: 'src', type: DirentType.Directory },
+          ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }]),
+        ]
+      }
+      return moved ? [{ name: 'Main.elm', type: DirentType.File }] : []
+    },
+    'FileSystem.rename'() {
+      moved = true
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    items: [
+      { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.Directory },
+      { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },
+    ],
+    root: '/workspace',
+  }
+
+  const result = await handleDrop(state, 0, 0, [1])
+
+  expect(result.items.map((item) => item.path)).toEqual(['/workspace/src', '/workspace/src/Main.elm'])
+  expect(dragRpc.invocations).toEqual([['DragAndDrop.getDroppedItems', [1], false]])
+  expect(mockRpc.invocations).toContainEqual(['FileSystem.rename', '/workspace/Main.elm', '/workspace/src/Main.elm'])
+})
+
+test('handleDrop - wraps internal move failures', async () => {
+  using _dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.getDroppedItems'() {
+      return { files: [], strings: [], uris: ['file:///workspace/Main.elm'] }
+    },
+  })
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.rename'() {
+      throw new Error('permission denied')
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    items: [
+      { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.Directory },
+      { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },
+    ],
+    root: '/workspace',
+  }
+
+  await expect(handleDrop(state, 0, 0, [1])).rejects.toThrow('Failed to drop files: permission denied')
 })

--- a/packages/explorer-view/test/HandleInternalDrop.test.ts
+++ b/packages/explorer-view/test/HandleInternalDrop.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
+import * as DirentType from '../src/parts/DirentType/DirentType.ts'
+import { handleInternalDrop } from '../src/parts/HandleInternalDrop/HandleInternalDrop.ts'
+
+test('moves a workspace file into a folder and expands the target', async () => {
+  let moved = false
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readDirWithFileTypes'(path: string) {
+      if (path === '/workspace') {
+        return [
+          { name: 'src', type: DirentType.Directory },
+          ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }]),
+        ]
+      }
+      if (path === '/workspace/src') {
+        return moved ? [{ name: 'Main.elm', type: DirentType.File }] : []
+      }
+      return []
+    },
+    'FileSystem.rename'() {
+      moved = true
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    dropTargets: [0],
+    items: [
+      { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.Directory },
+      { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },
+    ],
+    root: '/workspace',
+  }
+
+  const result = await handleInternalDrop(state, ['/workspace/Main.elm'], 0)
+
+  expect(result.dropTargets).toEqual([])
+  expect(result.items).toEqual([
+    expect.objectContaining({ name: 'src', path: '/workspace/src', type: DirentType.DirectoryExpanded }),
+    expect.objectContaining({ name: 'Main.elm', path: '/workspace/src/Main.elm', type: DirentType.File }),
+  ])
+  expect(mockRpc.invocations).toContainEqual(['FileSystem.rename', '/workspace/Main.elm', '/workspace/src/Main.elm'])
+})
+
+test('does not move a file when it is already in the target folder', async () => {
+  const state = {
+    ...createDefaultState(),
+    dropTargets: [0],
+    items: [
+      { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.DirectoryExpanded },
+      { depth: 2, name: 'Main.elm', path: '/workspace/src/Main.elm', selected: false, type: DirentType.File },
+    ],
+    root: '/workspace',
+  }
+
+  const result = await handleInternalDrop(state, ['/workspace/src/Main.elm'], 0)
+
+  expect(result).toEqual({ ...state, dropTargets: [] })
+})
+
+test('rejects moving a folder into its descendant before changing the file system', async () => {
+  const state = {
+    ...createDefaultState(),
+    items: [
+      { depth: 1, name: 'folder', path: '/workspace/folder', selected: false, type: DirentType.DirectoryExpanded },
+      { depth: 2, name: 'child', path: '/workspace/folder/child', selected: false, type: DirentType.Directory },
+    ],
+    root: '/workspace',
+  }
+
+  await expect(handleInternalDrop(state, ['/workspace/folder'], 1)).rejects.toThrow(
+    'Cannot move folder folder into a subfolder of itself',
+  )
+})
+
+test('rejects a visible destination collision before changing the file system', async () => {
+  const state = {
+    ...createDefaultState(),
+    items: [
+      { depth: 1, name: 'src', path: '/workspace/src', selected: false, type: DirentType.DirectoryExpanded },
+      { depth: 2, name: 'Main.elm', path: '/workspace/src/Main.elm', selected: false, type: DirentType.File },
+      { depth: 1, name: 'Main.elm', path: '/workspace/Main.elm', selected: false, type: DirentType.File },
+    ],
+    root: '/workspace',
+  }
+
+  await expect(handleInternalDrop(state, ['/workspace/Main.elm'], 0)).rejects.toThrow(
+    'A file or folder **Main.elm** already exists at this location. Please choose a different name.',
+  )
+})

--- a/packages/explorer-view/test/HandleInternalDrop.test.ts
+++ b/packages/explorer-view/test/HandleInternalDrop.test.ts
@@ -9,10 +9,7 @@ test('moves a workspace file into a folder and expands the target', async () => 
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readDirWithFileTypes'(path: string) {
       if (path === '/workspace') {
-        return [
-          { name: 'src', type: DirentType.Directory },
-          ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }]),
-        ]
+        return [{ name: 'src', type: DirentType.Directory }, ...(moved ? [] : [{ name: 'Main.elm', type: DirentType.File }])]
       }
       if (path === '/workspace/src') {
         return moved ? [{ name: 'Main.elm', type: DirentType.File }] : []
@@ -69,9 +66,7 @@ test('rejects moving a folder into its descendant before changing the file syste
     root: '/workspace',
   }
 
-  await expect(handleInternalDrop(state, ['/workspace/folder'], 1)).rejects.toThrow(
-    'Cannot move folder folder into a subfolder of itself',
-  )
+  await expect(handleInternalDrop(state, ['/workspace/folder'], 1)).rejects.toThrow('Cannot move folder folder into a subfolder of itself')
 })
 
 test('rejects a visible destination collision before changing the file system', async () => {


### PR DESCRIPTION
Fix internal Explorer drag and drop so workspace files move into the targeted folder. Preserve workspace URI schemes, validate unsafe or conflicting moves, surface filesystem failures, and enable the focused Explorer regression test.