### PR TITLE
feature: render explorer commands directly

### DIFF
--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 608_000
+const threshold = 610_000
 
 const instantiations = 200_000
 

--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -53,6 +53,7 @@ import * as HandleInputBlur from '../HandleInputBlur/HandleInputBlur.ts'
 import * as HandleInputClick from '../HandleInputClick/HandleInputClick.ts'
 import * as HandleInputKeyDown from '../HandleInputKeyDown/HandleInputKeyDown.ts'
 import * as HandleKeyDown from '../HandleKeyDown/HandleKeyDown.ts'
+import * as HandleMessagePort from '../HandleMessagePort/HandleMessagePort.ts'
 import * as HandleNativePaste from '../HandleNativePaste/HandleNativePaste.ts'
 import * as HandlePaste from '../HandlePaste/HandlePaste.ts'
 import * as HandlePointerDown from '../HandlePointerDown/HandlePointerDown.ts'
@@ -146,6 +147,7 @@ export const commandMap = {
   'Explorer.handleInputClick': WrapCommand.wrapListItemCommand(HandleInputClick.handleInputClick),
   'Explorer.handleInputKeyDown': WrapCommand.wrapListItemCommand(HandleInputKeyDown.handleInputKeyDown),
   'Explorer.handleKeyDown': WrapCommand.wrapListItemCommand(HandleKeyDown.handleKeyDown),
+  'Explorer.handleMessagePort': HandleMessagePort.handleMessagePort,
   'Explorer.handleNativePaste': WrapCommand.wrapListItemCommand(HandleNativePaste.handleNativePaste),
   'Explorer.handlePaste': WrapCommand.wrapListItemCommand(HandlePaste.handlePaste),
   'Explorer.handlePointerDown': WrapCommand.wrapListItemCommand(HandlePointerDown.handlePointerDown),

--- a/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,0 +1,10 @@
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
+
+export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+  const rpc = await PlainMessagePortRpc.create({
+    commandMap: {},
+    messagePort: port,
+  })
+  RendererProcess.set(rpc)
+}

--- a/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,5 +1,5 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const handleMessagePort = async (port: MessagePort): Promise<void> => {
   const rpc = await PlainMessagePortRpc.create({

--- a/packages/explorer-view/src/parts/Render2/Render2.ts
+++ b/packages/explorer-view/src/parts/Render2/Render2.ts
@@ -1,14 +1,17 @@
 import { ViewletCommand } from '@lvce-editor/constants'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
 import * as Diff from '../Diff/Diff.ts'
 import * as ExplorerStates from '../ExplorerStates/ExplorerStates.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const render2 = async (uid: number, _diffResult: readonly number[]): Promise<readonly any[]> => {
   const { oldState, scheduledState } = ExplorerStates.get(uid)
   const diffResult = Diff.diff(oldState, scheduledState)
   ExplorerStates.set(uid, scheduledState, scheduledState)
   const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
+  if (!RendererProcess.isConnected()) {
+    return commands
+  }
   const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommand.SetFocusContext)
   const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommand.SetFocusContext)
   const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)

--- a/packages/explorer-view/src/parts/Render2/Render2.ts
+++ b/packages/explorer-view/src/parts/Render2/Render2.ts
@@ -1,11 +1,16 @@
+import { ViewletCommand } from '@lvce-editor/constants'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
 import * as ApplyRender from '../ApplyRender/ApplyRender.ts'
 import * as Diff from '../Diff/Diff.ts'
 import * as ExplorerStates from '../ExplorerStates/ExplorerStates.ts'
 
-export const render2 = (uid: number, _diffResult: readonly number[]): readonly any[] => {
+export const render2 = async (uid: number, _diffResult: readonly number[]): Promise<readonly any[]> => {
   const { oldState, scheduledState } = ExplorerStates.get(uid)
   const diffResult = Diff.diff(oldState, scheduledState)
   ExplorerStates.set(uid, scheduledState, scheduledState)
   const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
-  return commands
+  const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommand.SetFocusContext)
+  const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommand.SetFocusContext)
+  const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
+  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
 }

--- a/packages/explorer-view/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/explorer-view/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,20 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry } from '@lvce-editor/rpc-registry'
+
+const state = {
+  connected: false,
+}
+
+export const isConnected = (): boolean => {
+  const { connected } = state
+  return connected
+}
+
+export const invoke = (method: string, ...params: readonly unknown[]): Promise<any> => {
+  return RendererProcessRegistry.invoke(method, ...params)
+}
+
+export const set = (rpc: Rpc): void => {
+  RendererProcessRegistry.set(rpc)
+  state.connected = true
+}

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { RendererProcess, RendererWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
@@ -161,6 +162,7 @@ test('wrapListItemCommand continues after a command fails', async () => {
 })
 
 test('wrapListItemCommand preserves user input when a pending render commits', async () => {
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': () => 1 } }))
   const uid = 9005
   const state = {
     ...createDefaultState(),
@@ -180,7 +182,7 @@ test('wrapListItemCommand preserves user input when a pending render commits', a
 
   ExplorerStates.set(uid, state, state)
   await wrapped(uid)
-  Render2.render2(uid, [])
+  await Render2.render2(uid, [])
 
   const { newState } = ExplorerStates.get(uid)
   expect(newState.editingValue).toBe('new.txt')

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { RendererProcess, RendererWorker } from '@lvce-editor/rpc-registry'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DirentType from '../src/parts/DirentType/DirentType.ts'
 import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
@@ -9,6 +9,7 @@ import * as GetVisibleExplorerItems from '../src/parts/GetVisibleExplorerItems/G
 import * as HandleClickFile from '../src/parts/HandleClickFile/HandleClickFile.ts'
 import * as InputSource from '../src/parts/InputSource/InputSource.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 test('wrapListItemCommand recomputes visible items when focus changes', async () => {
   const uid = 9001

--- a/packages/explorer-view/test/HandleMessagePort.test.ts
+++ b/packages/explorer-view/test/HandleMessagePort.test.ts
@@ -1,0 +1,22 @@
+import { expect, jest, test } from '@jest/globals'
+import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+
+test('handleMessagePort connects the explorer worker to the renderer process', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
+  const { port1, port2 } = new MessageChannel()
+  const rendererProcessRpc = await PlainMessagePortRpcParent.create({
+    commandMap: {
+      'Viewlet.queueCommands': queueCommands,
+    },
+    messagePort: port1,
+  })
+
+  await handleMessagePort(port2)
+  await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
+  expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
+
+  await RendererProcess.dispose()
+  await rendererProcessRpc.dispose()
+})

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -1,10 +1,22 @@
-import { test, expect } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
+import { WhenExpression } from '@lvce-editor/constants'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DiffType from '../src/parts/DiffType/DiffType.ts'
 import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
+import * as FocusId from '../src/parts/FocusId/FocusId.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
 
-test('render2 - recomputes a stale diff before rendering', () => {
+test('render2 - queues renderer commands and returns a lightweight commit marker', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
+  RendererProcess.set(
+    createMockRpc({
+      commandMap: {
+        'Viewlet.queueCommands': queueCommands,
+      },
+    }),
+  )
   const uid = 1
   const staleDiffResult = [DiffType.RenderFocus]
   const oldState = createDefaultState()
@@ -13,6 +25,25 @@ test('render2 - recomputes a stale diff before rendering', () => {
     items: [...oldState.items],
   }
   ExplorerStates.set(uid, oldState, newState)
-  const result = Render2.render2(uid, staleDiffResult)
-  expect(result).toEqual([['Viewlet.setPatches', 1, []]])
+  const result = await Render2.render2(uid, staleDiffResult)
+
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.setPatches', 1, []]])
+  expect(result).toEqual([['Viewlet.commitPending', uid, 17]])
+})
+
+test('render2 - leaves focus context management with the renderer worker', async () => {
+  const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 23)
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
+  const uid = 2
+  const oldState = { ...createDefaultState(), uid }
+  const newState = { ...oldState, focus: FocusId.List }
+  ExplorerStates.set(uid, oldState, newState)
+
+  const result = await Render2.render2(uid, [])
+
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.focusSelector', '.ListItems']])
+  expect(result).toEqual([
+    ['Viewlet.setFocusContext', uid, WhenExpression.FocusExplorer],
+    ['Viewlet.commitPending', uid, 23],
+  ])
 })

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -1,12 +1,24 @@
 import { expect, jest, test } from '@jest/globals'
 import { WhenExpression } from '@lvce-editor/constants'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as DiffType from '../src/parts/DiffType/DiffType.ts'
 import * as ExplorerStates from '../src/parts/ExplorerStates/ExplorerStates.ts'
 import * as FocusId from '../src/parts/FocusId/FocusId.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
+
+test('render2 - returns renderer commands when no direct renderer is connected', async () => {
+  const uid = 3
+  const oldState = { ...createDefaultState(), uid }
+  const newState = {
+    ...oldState,
+    items: [...oldState.items],
+  }
+  ExplorerStates.set(uid, oldState, newState)
+
+  await expect(Render2.render2(uid, [])).resolves.toEqual([['Viewlet.setPatches', uid, []]])
+})
 
 test('render2 - queues renderer commands and returns a lightweight commit marker', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)

--- a/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
+++ b/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
@@ -1,4 +1,6 @@
-import { expect, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import { createMockRpc } from '@lvce-editor/rpc'
+import { RendererProcess } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as Diff2 from '../src/parts/Diff2/Diff2.ts'
@@ -9,7 +11,14 @@ import { handlePointerUp } from '../src/parts/HandlePointerUp/HandlePointerUp.ts
 import * as MouseEventType from '../src/parts/MouseEventType/MouseEventType.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
 
-test('pointer down renders drag data for the pointed explorer item', () => {
+const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 1)
+
+beforeEach(() => {
+  queueCommands.mockClear()
+  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': queueCommands } }))
+})
+
+test('pointer down renders drag data for the pointed explorer item', async () => {
   const uid = 42
   const oldState: ExplorerState = {
     ...createDefaultState(),
@@ -22,9 +31,9 @@ test('pointer down renders drag data for the pointed explorer item', () => {
   const newState = handlePointerDown(oldState, MouseEventType.LeftClick, 0, 0)
   ExplorerStates.set(uid, oldState, newState)
   const diffResult = Diff2.diff2(uid)
-  const commands = Render2.render2(uid, diffResult)
+  await Render2.render2(uid, diffResult)
 
-  expect(commands).toEqual([
+  expect(queueCommands).toHaveBeenCalledWith(uid, [
     [
       'Viewlet.setDragData',
       uid,
@@ -39,7 +48,7 @@ test('pointer down renders drag data for the pointed explorer item', () => {
   ])
 })
 
-test('pointer up rearms drag data rendering for repeated drags', () => {
+test('pointer up rearms drag data rendering for repeated drags', async () => {
   const uid = 43
   const initialState: ExplorerState = {
     ...createDefaultState(),
@@ -54,15 +63,15 @@ test('pointer up rearms drag data rendering for repeated drags', () => {
 
   const pointerDownState = handlePointerDown(initialState, MouseEventType.LeftClick, 0, initialState.itemHeight)
   ExplorerStates.set(uid, initialState, pointerDownState)
-  const firstCommands = Render2.render2(uid, Diff2.diff2(uid))
+  await Render2.render2(uid, Diff2.diff2(uid))
 
   const pointerUpState = handlePointerUp(pointerDownState)
   ExplorerStates.set(uid, pointerDownState, pointerUpState)
-  expect(Render2.render2(uid, Diff2.diff2(uid))).toEqual([])
+  await Render2.render2(uid, Diff2.diff2(uid))
 
   const secondPointerDownState = handlePointerDown(pointerUpState, MouseEventType.LeftClick, 0, initialState.itemHeight)
   ExplorerStates.set(uid, pointerUpState, secondPointerDownState)
-  const secondCommands = Render2.render2(uid, Diff2.diff2(uid))
+  await Render2.render2(uid, Diff2.diff2(uid))
 
   const expectedCommand = [
     'Viewlet.setDragData',
@@ -75,11 +84,12 @@ test('pointer up rearms drag data rendering for repeated drags', () => {
       label: 'second.txt',
     },
   ]
-  expect(firstCommands).toEqual([expectedCommand])
-  expect(secondCommands).toEqual([expectedCommand])
+  expect(queueCommands).toHaveBeenNthCalledWith(1, uid, [expectedCommand])
+  expect(queueCommands).toHaveBeenNthCalledWith(2, uid, [])
+  expect(queueCommands).toHaveBeenNthCalledWith(3, uid, [expectedCommand])
 })
 
-test('pointer down on a selected item renders drag data for the full effective selection', () => {
+test('pointer down on a selected item renders drag data for the full effective selection', async () => {
   const uid = 44
   const oldState: ExplorerState = {
     ...createDefaultState(),
@@ -95,7 +105,9 @@ test('pointer down on a selected item renders drag data for the full effective s
   const newState = handlePointerDown(oldState, MouseEventType.LeftClick, 0, oldState.itemHeight)
   ExplorerStates.set(uid, oldState, newState)
 
-  expect(Render2.render2(uid, Diff2.diff2(uid))).toEqual([
+  await Render2.render2(uid, Diff2.diff2(uid))
+
+  expect(queueCommands).toHaveBeenCalledWith(uid, [
     [
       'Viewlet.setDragData',
       uid,

--- a/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
+++ b/packages/explorer-view/test/RenderDragDataLifecycle.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import { createMockRpc } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../src/parts/ExplorerState/ExplorerState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as Diff2 from '../src/parts/Diff2/Diff2.ts'
@@ -10,6 +9,7 @@ import { handlePointerDown } from '../src/parts/HandlePointerDown/HandlePointerD
 import { handlePointerUp } from '../src/parts/HandlePointerUp/HandlePointerUp.ts'
 import * as MouseEventType from '../src/parts/MouseEventType/MouseEventType.ts'
 import * as Render2 from '../src/parts/Render2/Render2.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
 const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 1)
 


### PR DESCRIPTION
Queue Explorer DOM and render commands directly in the renderer process while returning only renderer-worker-owned focus context and a lightweight commit marker.