### PR TITLE
fix: focus explorer input after direct render

### DIFF
--- a/packages/explorer-view/src/parts/RenderFocus/RenderFocus.ts
+++ b/packages/explorer-view/src/parts/RenderFocus/RenderFocus.ts
@@ -9,10 +9,10 @@ export const renderFocus = (oldState: ExplorerState, newState: ExplorerState): r
     return []
   }
   if (newState.focus === FocusId.Input) {
-    return [ViewletCommand.FocusElementByName, InputName.ExplorerInput]
+    return [ViewletCommand.FocusElementByName, newState.uid, InputName.ExplorerInput]
   }
   if (newState.focus === FocusId.List) {
-    return [ViewletCommand.FocusSelector, '.ListItems']
+    return [ViewletCommand.FocusSelector, newState.uid, '.ListItems']
   }
   // TODO
   // 1. when focused, focus the outer list element

--- a/packages/explorer-view/src/parts/RenderValue/RenderValue.ts
+++ b/packages/explorer-view/src/parts/RenderValue/RenderValue.ts
@@ -8,7 +8,7 @@ export const renderValue = (oldState: ExplorerState, newState: ExplorerState): r
     return []
   }
   if (newState.focus === FocusId.Input) {
-    return ['Viewlet.setValueByName', InputName.ExplorerInput, newState.editingValue]
+    return ['Viewlet.setValueByName', newState.uid, InputName.ExplorerInput, newState.editingValue]
   }
   return []
 }

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -53,7 +53,7 @@ test('render2 - leaves focus context management with the renderer worker', async
 
   const result = await Render2.render2(uid, [])
 
-  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.focusSelector', '.ListItems']])
+  expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.focusSelector', uid, '.ListItems']])
   expect(result).toEqual([
     ['Viewlet.setFocusContext', uid, WhenExpression.FocusExplorer],
     ['Viewlet.commitPending', uid, 23],

--- a/packages/explorer-view/test/RenderFocus.test.ts
+++ b/packages/explorer-view/test/RenderFocus.test.ts
@@ -22,7 +22,7 @@ test('focus input when focus is input', () => {
     focus: FocusId.Input,
   }
   const result = renderFocus(oldState, newState)
-  expect(result).toEqual(['Viewlet.focusElementByName', InputName.ExplorerInput])
+  expect(result).toEqual(['Viewlet.focusElementByName', newState.uid, InputName.ExplorerInput])
 })
 
 test('focus list when focus is list', () => {
@@ -32,7 +32,7 @@ test('focus list when focus is list', () => {
     focus: FocusId.List,
   }
   const result = renderFocus(oldState, newState)
-  expect(result).toEqual(['Viewlet.focusSelector', '.ListItems'])
+  expect(result).toEqual(['Viewlet.focusSelector', newState.uid, '.ListItems'])
 })
 
 test('empty array when no focus state', () => {

--- a/packages/explorer-view/test/RenderValue.test.ts
+++ b/packages/explorer-view/test/RenderValue.test.ts
@@ -20,7 +20,7 @@ test('should return setValue command when focus is Input', () => {
 
   const result = renderValue(oldState, newState)
 
-  expect(result).toEqual(['Viewlet.setValueByName', InputName.ExplorerInput, 'test-value'])
+  expect(result).toEqual(['Viewlet.setValueByName', newState.uid, InputName.ExplorerInput, 'test-value'])
 })
 
 test('should return empty array when focus is not Input', () => {


### PR DESCRIPTION
Fixes Explorer direct-render commands so input focus and programmatic value updates include the owning viewlet UID. This restores immediate typing after pressing New File while preserving direct Explorer-to-renderer dispatch.