### PR TITLE
fix: focus editor after creating file

### DIFF
--- a/packages/e2e/src/viewlet.explorer-focus-after-create-file.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-after-create-file.ts
@@ -2,10 +2,12 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-focus-after-create-file'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Workspace }) => {
+export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   const tmpDir = await FileSystem.getTmpDir()
   await FileSystem.writeFile(`${tmpDir}/file1.txt`, 'content 1')
+  // Keep this focus test independent of browser-specific font loading behavior.
+  await Settings.update({ 'editor.fontFamily': 'monospace' })
   await Workspace.setPath(tmpDir)
 
   // act

--- a/packages/e2e/src/viewlet.explorer-focus-after-create-file.ts
+++ b/packages/e2e/src/viewlet.explorer-focus-after-create-file.ts
@@ -13,8 +13,10 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Worksp
   await Explorer.updateEditingValue('new-file.txt')
   await Explorer.acceptEdit()
 
-  // assert - the new file should be visible and focused
+  // assert - the new file should remain selected and the editor should be focused
   const newFile = Locator('.TreeItem[aria-label="new-file.txt"]')
+  const editorInput = Locator('.EditorInput textarea')
   await expect(newFile).toBeVisible()
   await expect(newFile).toHaveId('TreeItemActive')
+  await expect(editorInput).toBeFocused()
 }

--- a/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
+++ b/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
@@ -1,3 +1,4 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
 import { createTree } from '../CreateTree/CreateTree.ts'
@@ -16,6 +17,12 @@ import { join2 } from '../Path/Path.ts'
 import { refreshWorkspace } from '../RefreshWorkspace/RefreshWorkspace.ts'
 import { treeToArray } from '../TreeToArray/TreeToArray.ts'
 import * as ValidateFileName2 from '../ValidateFileName2/ValidateFileName2.ts'
+
+const focusEditorAfterExplorerRender = (): void => {
+  setTimeout(() => {
+    void RendererWorker.invoke('Main.focus')
+  }, 0)
+}
 
 export const acceptCreate = async (state: ExplorerState, newDirentType: number): Promise<ExplorerState> => {
   const { editingValue, excluded, focusedIndex, items, pathSeparator, root } = state
@@ -55,6 +62,7 @@ export const acceptCreate = async (state: ExplorerState, newDirentType: number):
 
   if (newDirentType === DirentType.File) {
     await openUri(absolutePath, true)
+    focusEditorAfterExplorerRender()
   }
 
   return {

--- a/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
+++ b/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
@@ -1,4 +1,3 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
 import { createTree } from '../CreateTree/CreateTree.ts'
@@ -56,7 +55,6 @@ export const acceptCreate = async (state: ExplorerState, newDirentType: number):
 
   if (newDirentType === DirentType.File) {
     await openUri(absolutePath, true)
-    await RendererWorker.invoke('Main.focus')
   }
 
   return {

--- a/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
+++ b/packages/explorer-view/src/parts/AcceptCreate/AcceptCreate.ts
@@ -1,3 +1,4 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as ApplyFileOperations from '../ApplyFileOperations/ApplyFileOperations.ts'
 import { createTree } from '../CreateTree/CreateTree.ts'
@@ -55,13 +56,14 @@ export const acceptCreate = async (state: ExplorerState, newDirentType: number):
 
   if (newDirentType === DirentType.File) {
     await openUri(absolutePath, true)
+    await RendererWorker.invoke('Main.focus')
   }
 
   return {
     ...state,
     editingIndex: -1,
     editingType: ExplorerEditingType.None,
-    focus: FocusId.List,
+    focus: newDirentType === DirentType.File ? FocusId.None : FocusId.List,
     focusedIndex: newFocusedIndex,
     items: dirents,
   }

--- a/packages/explorer-view/test/AcceptCreate.test.ts
+++ b/packages/explorer-view/test/AcceptCreate.test.ts
@@ -47,6 +47,7 @@ test('acceptCreate - successful file creation', async () => {
     'IconTheme.getIcons'() {
       return Array(2).fill('')
     },
+    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -86,7 +87,7 @@ test('acceptCreate - successful file creation', async () => {
     ...state,
     editingIndex: -1,
     editingType: ExplorerEditingType.None,
-    focus: FocusId.List,
+    focus: FocusId.None,
     focusedIndex: 1,
     items: [
       {
@@ -118,6 +119,7 @@ test('acceptCreate - successful file creation', async () => {
     ['FileSystem.readDirWithFileTypes', 'memfs:///workspace/test'],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'memfs:///workspace/test/test.txt' }],
+    ['Main.focus'],
   ])
 })
 
@@ -184,6 +186,7 @@ test('acceptCreate - successful folder creation does not open uri', async () => 
   const result = await acceptCreate(state, DirentType.Directory)
   expect(result.editingIndex).toBe(-1)
   expect(result.editingType).toBe(ExplorerEditingType.None)
+  expect(result.focus).toBe(FocusId.List)
   expect(mockRpc.invocations).toEqual([
     ['FileSystem.mkdir', 'memfs:///workspace/test'],
     ['FileSystem.mkdir', 'memfs:///workspace/test/newfolder'],

--- a/packages/explorer-view/test/AcceptCreate.test.ts
+++ b/packages/explorer-view/test/AcceptCreate.test.ts
@@ -47,7 +47,6 @@ test('acceptCreate - successful file creation', async () => {
     'IconTheme.getIcons'() {
       return Array(2).fill('')
     },
-    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -119,7 +118,6 @@ test('acceptCreate - successful file creation', async () => {
     ['FileSystem.readDirWithFileTypes', 'memfs:///workspace/test'],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'memfs:///workspace/test/test.txt' }],
-    ['Main.focus'],
   ])
 })
 

--- a/packages/explorer-view/test/AcceptCreate.test.ts
+++ b/packages/explorer-view/test/AcceptCreate.test.ts
@@ -47,6 +47,7 @@ test('acceptCreate - successful file creation', async () => {
     'IconTheme.getIcons'() {
       return Array(2).fill('')
     },
+    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -119,6 +120,8 @@ test('acceptCreate - successful file creation', async () => {
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'memfs:///workspace/test/test.txt' }],
   ])
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(mockRpc.invocations.at(-1)).toEqual(['Main.focus'])
 })
 
 test('acceptCreate - successful folder creation does not open uri', async () => {

--- a/packages/explorer-view/test/AcceptCreateFile.test.ts
+++ b/packages/explorer-view/test/AcceptCreateFile.test.ts
@@ -22,6 +22,7 @@ test('acceptCreateFile', async () => {
     'IconTheme.getIcons'() {
       return ['folder-icon']
     },
+    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -48,4 +49,6 @@ test('acceptCreateFile', async () => {
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'test/test.txt' }],
   ])
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(mockRpc.invocations.at(-1)).toEqual(['Main.focus'])
 })

--- a/packages/explorer-view/test/AcceptCreateFile.test.ts
+++ b/packages/explorer-view/test/AcceptCreateFile.test.ts
@@ -22,7 +22,6 @@ test('acceptCreateFile', async () => {
     'IconTheme.getIcons'() {
       return ['folder-icon']
     },
-    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -48,6 +47,5 @@ test('acceptCreateFile', async () => {
     ['FileSystem.writeFile', 'test/test.txt', ''],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'test/test.txt' }],
-    ['Main.focus'],
   ])
 })

--- a/packages/explorer-view/test/AcceptCreateFile.test.ts
+++ b/packages/explorer-view/test/AcceptCreateFile.test.ts
@@ -22,6 +22,7 @@ test('acceptCreateFile', async () => {
     'IconTheme.getIcons'() {
       return ['folder-icon']
     },
+    'Main.focus'() {},
     'Main.openUri'() {},
   })
 
@@ -47,5 +48,6 @@ test('acceptCreateFile', async () => {
     ['FileSystem.writeFile', 'test/test.txt', ''],
     ['Layout.handleWorkspaceRefresh'],
     ['Main.openUri', { focus: true, uri: 'test/test.txt' }],
+    ['Main.focus'],
   ])
 })


### PR DESCRIPTION
Focus the newly opened editor after a file is created from Explorer while keeping the created file selected in the tree. Adds regression coverage for the editor DOM focus handoff.