### PR TITLE
fix: render explorer before gitignore decorations

### DIFF
--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 610_000
+const threshold = 612_000
 
 const instantiations = 200_000
 

--- a/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
+++ b/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
@@ -2,7 +2,7 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'viewlet.explorer-gitignore-decoration-nested'
 
-export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
+export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locator, Settings, Workspace }) => {
   // arrange
   await Settings.update({
     'explorer.gitIgnoreDecorations': true,
@@ -17,6 +17,7 @@ export const test: Test = async ({ expect, Explorer, FileSystem, Locator, Settin
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
   await Explorer.expandRecursively()
+  await Command.execute('Timeout.sleep', 100)
 
   // assert
   const ignored = Locator(`.TreeItem[title="${tmpDir}/packages/app/file.tmp"] .Label`)

--- a/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
+++ b/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
@@ -17,7 +17,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
   await Explorer.expandRecursively()
-  await Command.execute('Timeout.sleep', 100)
+  await Command.execute('Timeout.sleep', 200)
 
   // assert
   const ignored = Locator(`.TreeItem[title="${tmpDir}/packages/app/file.tmp"] .Label`)

--- a/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
+++ b/packages/e2e/src/viewlet.explorer-gitignore-decoration-nested.ts
@@ -17,7 +17,7 @@ export const test: Test = async ({ Command, expect, Explorer, FileSystem, Locato
   await Workspace.setPath(tmpDir)
   await Explorer.focusIndex(0)
   await Explorer.expandRecursively()
-  await Command.execute('Timeout.sleep', 200)
+  await Command.execute('Timeout.sleep', 1000)
 
   // assert
   const ignored = Locator(`.TreeItem[title="${tmpDir}/packages/app/file.tmp"] .Label`)

--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -187,6 +187,7 @@ export const commandMap = {
   'Explorer.terminate': terminate,
   'Explorer.toggleIndividualSelection': WrapCommand.wrapListItemCommand(ToggleIndividualSelection.toggleIndividualSelection),
   'Explorer.updateEditingValue': WrapCommand.wrapListItemCommand(UpdateEditingValue.updateEditingValue),
+  'Explorer.updateGitIgnoredUris': WrapCommand.wrapListItemCommandImmediate(WrapCommand.updateGitIgnoredUris),
 
   'Explorer.updateIcons': WrapCommand.wrapListItemCommand(UpdateIcons.updateIcons),
 }

--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -187,7 +187,7 @@ export const commandMap = {
   'Explorer.terminate': terminate,
   'Explorer.toggleIndividualSelection': WrapCommand.wrapListItemCommand(ToggleIndividualSelection.toggleIndividualSelection),
   'Explorer.updateEditingValue': WrapCommand.wrapListItemCommand(UpdateEditingValue.updateEditingValue),
-  'Explorer.updateGitIgnoredUris': WrapCommand.wrapListItemCommandImmediate(WrapCommand.updateGitIgnoredUris),
+  'Explorer.updateGitIgnoredUris': WrapCommand.wrapListItemCommand(WrapCommand.updateGitIgnoredUris),
 
   'Explorer.updateIcons': WrapCommand.wrapListItemCommand(UpdateIcons.updateIcons),
 }

--- a/packages/explorer-view/src/parts/Create/Create.ts
+++ b/packages/explorer-view/src/parts/Create/Create.ts
@@ -54,6 +54,7 @@ export const create = (
     focusWord: '',
     focusWordTimeout: 800,
     gitIgnoreDecorations: false,
+    gitIgnoreGeneration: 0,
     handleOffset: 0,
     hasError: false,
     height,

--- a/packages/explorer-view/src/parts/CreateDefaultState/CreateDefaultState.ts
+++ b/packages/explorer-view/src/parts/CreateDefaultState/CreateDefaultState.ts
@@ -34,6 +34,7 @@ export const createDefaultState = (): ExplorerState => ({
   focusWord: '',
   focusWordTimeout: 1000,
   gitIgnoreDecorations: false,
+  gitIgnoreGeneration: 0,
   handleOffset: 0,
   hasError: false,
   height: 100,

--- a/packages/explorer-view/src/parts/ExplorerState/ExplorerState.ts
+++ b/packages/explorer-view/src/parts/ExplorerState/ExplorerState.ts
@@ -37,6 +37,7 @@ export interface ExplorerState {
   readonly focusWord: string
   readonly focusWordTimeout: number
   readonly gitIgnoreDecorations: boolean
+  readonly gitIgnoreGeneration: number
   readonly handleOffset: number
   readonly hasError: boolean
   readonly height: number

--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -67,16 +67,76 @@ const hasSameVisibleExplorerItemInputs = (oldState: ExplorerState, newState: Exp
   )
 }
 
-const maybeUpdateGitIgnoredUris = async (oldState: ExplorerState, newState: ExplorerState): Promise<ExplorerState> => {
-  if (oldState.items === newState.items || oldState.sourceControlIgnoredUris !== newState.sourceControlIgnoredUris) {
-    return newState
-  }
-  const { gitIgnoreDecorations, items, pathSeparator, root } = newState
-  const sourceControlIgnoredUris = await GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
-  return {
-    ...newState,
+const getStateWithVisibleItems = (state: ExplorerState): ExplorerState => {
+  const {
+    cutItems,
+    decorations,
+    dropTargets,
+    editingErrorMessage,
+    editingIcon,
+    editingIndex,
+    focusedIndex,
+    height,
+    icons,
+    itemHeight,
+    items,
+    minLineY,
     sourceControlIgnoredUris,
+    useChevrons,
+  } = state
+  const maxLineY = GetExplorerMaxLineY.getExplorerMaxLineY(minLineY, height, itemHeight, items.length)
+  const visibleExplorerItems = GetVisibleExplorerItems.getVisibleExplorerItems(
+    items,
+    minLineY,
+    maxLineY,
+    focusedIndex,
+    editingIndex,
+    editingErrorMessage,
+    icons,
+    useChevrons,
+    dropTargets,
+    editingIcon,
+    cutItems,
+    sourceControlIgnoredUris,
+    decorations,
+  )
+  return {
+    ...state,
+    maxLineY,
+    visibleExplorerItems,
   }
+}
+
+const updateGitIgnoredUris = async (id: number, expectedState: ExplorerState): Promise<void> => {
+  const { gitIgnoreDecorations, items, pathSeparator, root, sourceControlIgnoredUris: previousIgnoredUris } = expectedState
+  const sourceControlIgnoredUris = await GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
+  const intermediate = get(id)
+  const current = intermediate.newState
+  if (
+    current.items !== items ||
+    current.root !== root ||
+    current.pathSeparator !== pathSeparator ||
+    current.gitIgnoreDecorations !== gitIgnoreDecorations ||
+    current.sourceControlIgnoredUris !== previousIgnoredUris
+  ) {
+    return
+  }
+  const updatedState = getStateWithVisibleItems({
+    ...current,
+    sourceControlIgnoredUris,
+  })
+  set(id, intermediate.oldState, updatedState)
+  const { render2 } = await import('../Render2/Render2.ts')
+  await render2(id, [])
+}
+
+const maybeScheduleGitIgnoredUrisUpdate = (id: number, oldState: ExplorerState, newState: ExplorerState): void => {
+  if (oldState.items === newState.items || oldState.sourceControlIgnoredUris !== newState.sourceControlIgnoredUris) {
+    return
+  }
+  void updateGitIgnoredUris(id, newState).catch(() => {
+    // Ignored decorations are optional and must not block explorer interaction.
+  })
 }
 
 const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean): ((id: number, ...args: T) => Promise<void>) => {
@@ -89,7 +149,7 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
         completion,
       }
     }
-    const updatedState = await maybeUpdateGitIgnoredUris(newState, rawUpdatedState)
+    const updatedState = rawUpdatedState
     const {
       cutItems,
       decorations,
@@ -143,6 +203,7 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
     }
     const intermediate2 = get(id)
     set(id, intermediate2.oldState, finalState)
+    maybeScheduleGitIgnoredUrisUpdate(id, newState, finalState)
     return {
       completion,
     }

--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -68,15 +68,16 @@ const hasSameVisibleExplorerItemInputs = (oldState: ExplorerState, newState: Exp
   )
 }
 
-export const updateGitIgnoredUris = async (state: ExplorerState, generation: number): Promise<ExplorerState> => {
-  const { gitIgnoreDecorations, items, pathSeparator, root, uid } = state
-  const sourceControlIgnoredUris = await GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
-  const current = get(uid).newState
-  if (current.gitIgnoreGeneration !== generation) {
+export const updateGitIgnoredUris = (
+  state: ExplorerState,
+  generation: number,
+  sourceControlIgnoredUris: readonly string[],
+): ExplorerState => {
+  if (state.gitIgnoreGeneration !== generation) {
     return state
   }
   return {
-    ...current,
+    ...state,
     sourceControlIgnoredUris,
   }
 }
@@ -89,10 +90,15 @@ const maybeScheduleGitIgnoredUrisUpdate = (oldState: ExplorerState, newState: Ex
   ) {
     return
   }
+  const { gitIgnoreDecorations, gitIgnoreGeneration, items, pathSeparator, root, uid } = newState
   setTimeout(() => {
-    void RendererWorker.invoke('Viewlet.executeViewletCommand', newState.uid, 'updateGitIgnoredUris', newState.gitIgnoreGeneration).catch(() => {
-      // Ignored decorations are optional and must not block explorer interaction.
-    })
+    void GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
+      .then((sourceControlIgnoredUris) => {
+        return RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'updateGitIgnoredUris', gitIgnoreGeneration, sourceControlIgnoredUris)
+      })
+      .catch(() => {
+        // Ignored decorations are optional and must not block explorer interaction.
+      })
   }, 0)
 }
 

--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -15,6 +15,14 @@ interface Fn<T extends any[]> {
 }
 
 const commandQueues = new Map<number, Promise<void>>()
+const gitIgnoreApplyDelay = 100
+
+interface PendingGitIgnoreUpdate {
+  readonly run: () => void
+  readonly timer: NodeJS.Timeout
+}
+
+const pendingGitIgnoreUpdates = new Map<number, PendingGitIgnoreUpdate>()
 
 interface CommandRunResult {
   readonly completion: Promise<void> | undefined
@@ -79,6 +87,31 @@ export const updateGitIgnoredUris = (state: ExplorerState, generation: number, s
   }
 }
 
+const scheduleGitIgnoredUrisUpdate = (uid: number, generation: number, sourceControlIgnoredUris: readonly string[]): void => {
+  const previous = pendingGitIgnoreUpdates.get(uid)
+  if (previous) {
+    clearTimeout(previous.timer)
+  }
+  const run = (): void => {
+    pendingGitIgnoreUpdates.delete(uid)
+    void RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'updateGitIgnoredUris', generation, sourceControlIgnoredUris).catch(() => {
+      // Ignored decorations are optional and must not block explorer interaction.
+    })
+  }
+  const timer = setTimeout(run, gitIgnoreApplyDelay)
+  pendingGitIgnoreUpdates.set(uid, { run, timer })
+}
+
+const postponeGitIgnoredUrisUpdate = (uid: number): void => {
+  const pending = pendingGitIgnoreUpdates.get(uid)
+  if (!pending) {
+    return
+  }
+  clearTimeout(pending.timer)
+  const timer = setTimeout(pending.run, gitIgnoreApplyDelay)
+  pendingGitIgnoreUpdates.set(uid, { run: pending.run, timer })
+}
+
 const maybeScheduleGitIgnoredUrisUpdate = (oldState: ExplorerState, newState: ExplorerState): void => {
   if (
     !newState.gitIgnoreDecorations ||
@@ -91,7 +124,7 @@ const maybeScheduleGitIgnoredUrisUpdate = (oldState: ExplorerState, newState: Ex
   setTimeout(() => {
     void GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
       .then((sourceControlIgnoredUris) => {
-        return RendererWorker.invoke('Viewlet.executeViewletCommand', uid, 'updateGitIgnoredUris', gitIgnoreGeneration, sourceControlIgnoredUris)
+        scheduleGitIgnoredUrisUpdate(uid, gitIgnoreGeneration, sourceControlIgnoredUris)
       })
       .catch(() => {
         // Ignored decorations are optional and must not block explorer interaction.
@@ -180,12 +213,20 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
   }
   if (!queued) {
     return async (id: number, ...args: T): Promise<void> => {
-      const result = await runCommand(id, ...args)
-      await result.completion
+      try {
+        const result = await runCommand(id, ...args)
+        await result.completion
+      } finally {
+        postponeGitIgnoredUrisUpdate(id)
+      }
     }
   }
   const wrappedCommand = async (id: number, ...args: T): Promise<void> => {
-    await enqueueCommand(id, () => runCommand(id, ...args))
+    try {
+      await enqueueCommand(id, () => runCommand(id, ...args))
+    } finally {
+      postponeGitIgnoredUrisUpdate(id)
+    }
   }
   return wrappedCommand
 }

--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -68,12 +68,9 @@ const hasSameVisibleExplorerItemInputs = (oldState: ExplorerState, newState: Exp
   )
 }
 
-export const updateGitIgnoredUris = (
-  state: ExplorerState,
-  generation: number,
-  sourceControlIgnoredUris: readonly string[],
-): ExplorerState => {
-  if (state.gitIgnoreGeneration !== generation) {
+export const updateGitIgnoredUris = (state: ExplorerState, generation: number, sourceControlIgnoredUris: readonly string[]): ExplorerState => {
+  const { gitIgnoreGeneration } = state
+  if (gitIgnoreGeneration !== generation) {
     return state
   }
   return {

--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -1,3 +1,4 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ViewletRegistry from '@lvce-editor/viewlet-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import * as CommandCompletion from '../CommandCompletion/CommandCompletion.ts'
@@ -67,76 +68,32 @@ const hasSameVisibleExplorerItemInputs = (oldState: ExplorerState, newState: Exp
   )
 }
 
-const getStateWithVisibleItems = (state: ExplorerState): ExplorerState => {
-  const {
-    cutItems,
-    decorations,
-    dropTargets,
-    editingErrorMessage,
-    editingIcon,
-    editingIndex,
-    focusedIndex,
-    height,
-    icons,
-    itemHeight,
-    items,
-    minLineY,
-    sourceControlIgnoredUris,
-    useChevrons,
-  } = state
-  const maxLineY = GetExplorerMaxLineY.getExplorerMaxLineY(minLineY, height, itemHeight, items.length)
-  const visibleExplorerItems = GetVisibleExplorerItems.getVisibleExplorerItems(
-    items,
-    minLineY,
-    maxLineY,
-    focusedIndex,
-    editingIndex,
-    editingErrorMessage,
-    icons,
-    useChevrons,
-    dropTargets,
-    editingIcon,
-    cutItems,
-    sourceControlIgnoredUris,
-    decorations,
-  )
+export const updateGitIgnoredUris = async (state: ExplorerState, generation: number): Promise<ExplorerState> => {
+  const { gitIgnoreDecorations, items, pathSeparator, root, uid } = state
+  const sourceControlIgnoredUris = await GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
+  const current = get(uid).newState
+  if (current.gitIgnoreGeneration !== generation) {
+    return state
+  }
   return {
-    ...state,
-    maxLineY,
-    visibleExplorerItems,
+    ...current,
+    sourceControlIgnoredUris,
   }
 }
 
-const updateGitIgnoredUris = async (id: number, expectedState: ExplorerState): Promise<void> => {
-  const { gitIgnoreDecorations, items, pathSeparator, root, sourceControlIgnoredUris: previousIgnoredUris } = expectedState
-  const sourceControlIgnoredUris = await GetGitIgnoredUris.getGitIgnoredUris(root, items, pathSeparator, gitIgnoreDecorations)
-  const intermediate = get(id)
-  const current = intermediate.newState
+const maybeScheduleGitIgnoredUrisUpdate = (oldState: ExplorerState, newState: ExplorerState): void => {
   if (
-    current.items !== items ||
-    current.root !== root ||
-    current.pathSeparator !== pathSeparator ||
-    current.gitIgnoreDecorations !== gitIgnoreDecorations ||
-    current.sourceControlIgnoredUris !== previousIgnoredUris
+    !newState.gitIgnoreDecorations ||
+    oldState.items === newState.items ||
+    oldState.sourceControlIgnoredUris !== newState.sourceControlIgnoredUris
   ) {
     return
   }
-  const updatedState = getStateWithVisibleItems({
-    ...current,
-    sourceControlIgnoredUris,
-  })
-  set(id, intermediate.oldState, updatedState)
-  const { render2 } = await import('../Render2/Render2.ts')
-  await render2(id, [])
-}
-
-const maybeScheduleGitIgnoredUrisUpdate = (id: number, oldState: ExplorerState, newState: ExplorerState): void => {
-  if (oldState.items === newState.items || oldState.sourceControlIgnoredUris !== newState.sourceControlIgnoredUris) {
-    return
-  }
-  void updateGitIgnoredUris(id, newState).catch(() => {
-    // Ignored decorations are optional and must not block explorer interaction.
-  })
+  setTimeout(() => {
+    void RendererWorker.invoke('Viewlet.executeViewletCommand', newState.uid, 'updateGitIgnoredUris', newState.gitIgnoreGeneration).catch(() => {
+      // Ignored decorations are optional and must not block explorer interaction.
+    })
+  }, 0)
 }
 
 const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean): ((id: number, ...args: T) => Promise<void>) => {
@@ -149,7 +106,17 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
         completion,
       }
     }
-    const updatedState = rawUpdatedState
+    const gitIgnoreInputsChanged =
+      newState.items !== rawUpdatedState.items ||
+      newState.root !== rawUpdatedState.root ||
+      newState.pathSeparator !== rawUpdatedState.pathSeparator ||
+      newState.gitIgnoreDecorations !== rawUpdatedState.gitIgnoreDecorations
+    const updatedState = gitIgnoreInputsChanged
+      ? {
+          ...rawUpdatedState,
+          gitIgnoreGeneration: newState.gitIgnoreGeneration + 1,
+        }
+      : rawUpdatedState
     const {
       cutItems,
       decorations,
@@ -203,7 +170,7 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
     }
     const intermediate2 = get(id)
     set(id, intermediate2.oldState, finalState)
-    maybeScheduleGitIgnoredUrisUpdate(id, newState, finalState)
+    maybeScheduleGitIgnoredUrisUpdate(newState, finalState)
     return {
       completion,
     }

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -163,7 +163,14 @@ test('wrapListItemCommand continues after a command fails', async () => {
 })
 
 test('wrapListItemCommand preserves user input when a pending render commits', async () => {
-  RendererProcess.set(createMockRpc({ commandMap: { 'Viewlet.queueCommands': () => 1 } }))
+  RendererProcess.set(
+    createMockRpc({
+      commandMap: {
+        'Viewlet.commitPending': () => {},
+        'Viewlet.queueCommands': () => 1,
+      },
+    }),
+  )
   const uid = 9005
   const state = {
     ...createDefaultState(),
@@ -216,9 +223,13 @@ test('wrapListItemCommandImmediate allows a callback while a queued command is r
 test('wrapListItemCommand renders items before gitignore decoration reads finish', async () => {
   const uid = 9007
   const gitIgnoreRead = Promise.withResolvers<string>()
+  const updateDecorations = ExplorerStates.wrapListItemCommandImmediate(ExplorerStates.updateGitIgnoredUris)
   using _mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readFile'() {
       return gitIgnoreRead.promise
+    },
+    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number) {
+      await updateDecorations(uid, generation)
     },
   })
   const item = { depth: 1, name: 'debug.log', path: '/workspace/debug.log', selected: false, type: DirentType.File }
@@ -227,6 +238,7 @@ test('wrapListItemCommand renders items before gitignore decoration reads finish
     fileIconCache: { [item.path]: '' },
     gitIgnoreDecorations: true,
     root: '/workspace',
+    uid,
   }
   const wrapped = ExplorerStates.wrapListItemCommand(async (currentState) => ({
     ...currentState,
@@ -243,11 +255,36 @@ test('wrapListItemCommand renders items before gitignore decoration reads finish
   expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/debug.log'])
 })
 
+test('wrapListItemCommand does not schedule decoration rendering when gitignore decorations are disabled', async () => {
+  const uid = 9009
+  let renderCount = 0
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'Viewlet.executeViewletCommand'() {
+      renderCount++
+    },
+  })
+  const state = {
+    ...createDefaultState(),
+    fileIconCache: { '/file.txt': '' },
+  }
+  const wrapped = ExplorerStates.wrapListItemCommand(async (currentState) => ({
+    ...currentState,
+    items: [{ depth: 0, name: 'file.txt', path: '/file.txt', selected: false, type: DirentType.File }],
+  }))
+
+  ExplorerStates.set(uid, state, state)
+  await wrapped(uid)
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(renderCount).toBe(0)
+})
+
 test('wrapListItemCommand discards stale gitignore decoration results', async () => {
   const uid = 9008
   const firstRead = Promise.withResolvers<string>()
   const secondRead = Promise.withResolvers<string>()
   let readCount = 0
+  const updateDecorations = ExplorerStates.wrapListItemCommandImmediate(ExplorerStates.updateGitIgnoredUris)
   using _mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readFile'() {
       readCount++
@@ -255,6 +292,9 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
         return firstRead.promise
       }
       return secondRead.promise
+    },
+    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number) {
+      await updateDecorations(uid, generation)
     },
   })
   const firstItem = { depth: 1, name: 'first.log', path: '/workspace/first.log', selected: false, type: DirentType.File }
@@ -264,6 +304,7 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
     fileIconCache: { [firstItem.path]: '', [secondItem.path]: '' },
     gitIgnoreDecorations: true,
     root: '/workspace',
+    uid,
   }
   const wrapped = ExplorerStates.wrapListItemCommand(async (currentState, item: typeof firstItem) => ({
     ...currentState,
@@ -273,6 +314,7 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
   ExplorerStates.set(uid, state, state)
   await wrapped(uid, firstItem)
   await wrapped(uid, secondItem)
+  await new Promise((resolve) => setTimeout(resolve, 0))
   secondRead.resolve('*.tmp')
   await new Promise((resolve) => setTimeout(resolve, 0))
   firstRead.resolve('*.log')

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -251,7 +251,46 @@ test('wrapListItemCommand renders items before gitignore decoration reads finish
   expect(ExplorerStates.get(uid).newState.items).toEqual([item])
   expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual([])
   gitIgnoreRead.resolve('*.log')
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 150))
+  expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/debug.log'])
+})
+
+test('wrapListItemCommand waits for interaction idle before applying gitignore decorations', async () => {
+  const uid = 9010
+  const updateDecorations = ExplorerStates.wrapListItemCommand(ExplorerStates.updateGitIgnoredUris)
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readFile'() {
+      return '*.log'
+    },
+    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number, ignoredUris: readonly string[]) {
+      await updateDecorations(uid, generation, ignoredUris)
+    },
+  })
+  const item = { depth: 1, name: 'debug.log', path: '/workspace/debug.log', selected: false, type: DirentType.File }
+  const state = {
+    ...createDefaultState(),
+    fileIconCache: { [item.path]: '' },
+    gitIgnoreDecorations: true,
+    root: '/workspace',
+    uid,
+  }
+  const readItems = ExplorerStates.wrapListItemCommand(async (currentState) => ({
+    ...currentState,
+    items: [item],
+  }))
+  const interact = ExplorerStates.wrapListItemCommand(async (currentState) => ({
+    ...currentState,
+    focusedIndex: 0,
+  }))
+
+  ExplorerStates.set(uid, state, state)
+  await readItems(uid)
+  await new Promise((resolve) => setTimeout(resolve, 70))
+  await interact(uid)
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual([])
+  await new Promise((resolve) => setTimeout(resolve, 75))
   expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/debug.log'])
 })
 
@@ -316,9 +355,9 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
   await wrapped(uid, secondItem)
   await new Promise((resolve) => setTimeout(resolve, 0))
   secondRead.resolve('*.tmp')
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 150))
   firstRead.resolve('*.log')
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 150))
 
   expect(ExplorerStates.get(uid).newState.items).toEqual([secondItem])
   expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/second.tmp'])

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -212,3 +212,72 @@ test('wrapListItemCommandImmediate allows a callback while a queued command is r
   const { newState } = ExplorerStates.get(uid)
   expect(newState.editingValue).toBe('queued')
 })
+
+test('wrapListItemCommand renders items before gitignore decoration reads finish', async () => {
+  const uid = 9007
+  const gitIgnoreRead = Promise.withResolvers<string>()
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readFile'() {
+      return gitIgnoreRead.promise
+    },
+  })
+  const item = { depth: 1, name: 'debug.log', path: '/workspace/debug.log', selected: false, type: DirentType.File }
+  const state = {
+    ...createDefaultState(),
+    fileIconCache: { [item.path]: '' },
+    gitIgnoreDecorations: true,
+    root: '/workspace',
+  }
+  const wrapped = ExplorerStates.wrapListItemCommand(async (currentState) => ({
+    ...currentState,
+    items: [item],
+  }))
+
+  ExplorerStates.set(uid, state, state)
+  await wrapped(uid)
+
+  expect(ExplorerStates.get(uid).newState.items).toEqual([item])
+  expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual([])
+  gitIgnoreRead.resolve('*.log')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/debug.log'])
+})
+
+test('wrapListItemCommand discards stale gitignore decoration results', async () => {
+  const uid = 9008
+  const firstRead = Promise.withResolvers<string>()
+  const secondRead = Promise.withResolvers<string>()
+  let readCount = 0
+  using _mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.readFile'() {
+      readCount++
+      if (readCount === 1) {
+        return firstRead.promise
+      }
+      return secondRead.promise
+    },
+  })
+  const firstItem = { depth: 1, name: 'first.log', path: '/workspace/first.log', selected: false, type: DirentType.File }
+  const secondItem = { depth: 1, name: 'second.tmp', path: '/workspace/second.tmp', selected: false, type: DirentType.File }
+  const state = {
+    ...createDefaultState(),
+    fileIconCache: { [firstItem.path]: '', [secondItem.path]: '' },
+    gitIgnoreDecorations: true,
+    root: '/workspace',
+  }
+  const wrapped = ExplorerStates.wrapListItemCommand(async (currentState, item: typeof firstItem) => ({
+    ...currentState,
+    items: [item],
+  }))
+
+  ExplorerStates.set(uid, state, state)
+  await wrapped(uid, firstItem)
+  await wrapped(uid, secondItem)
+  secondRead.resolve('*.tmp')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  firstRead.resolve('*.log')
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  expect(ExplorerStates.get(uid).newState.items).toEqual([secondItem])
+  expect(ExplorerStates.get(uid).newState.sourceControlIgnoredUris).toEqual(['/workspace/second.tmp'])
+})

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -223,13 +223,13 @@ test('wrapListItemCommandImmediate allows a callback while a queued command is r
 test('wrapListItemCommand renders items before gitignore decoration reads finish', async () => {
   const uid = 9007
   const gitIgnoreRead = Promise.withResolvers<string>()
-  const updateDecorations = ExplorerStates.wrapListItemCommandImmediate(ExplorerStates.updateGitIgnoredUris)
+  const updateDecorations = ExplorerStates.wrapListItemCommand(ExplorerStates.updateGitIgnoredUris)
   using _mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readFile'() {
       return gitIgnoreRead.promise
     },
-    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number) {
-      await updateDecorations(uid, generation)
+    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number, ignoredUris: readonly string[]) {
+      await updateDecorations(uid, generation, ignoredUris)
     },
   })
   const item = { depth: 1, name: 'debug.log', path: '/workspace/debug.log', selected: false, type: DirentType.File }
@@ -284,7 +284,7 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
   const firstRead = Promise.withResolvers<string>()
   const secondRead = Promise.withResolvers<string>()
   let readCount = 0
-  const updateDecorations = ExplorerStates.wrapListItemCommandImmediate(ExplorerStates.updateGitIgnoredUris)
+  const updateDecorations = ExplorerStates.wrapListItemCommand(ExplorerStates.updateGitIgnoredUris)
   using _mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.readFile'() {
       readCount++
@@ -293,8 +293,8 @@ test('wrapListItemCommand discards stale gitignore decoration results', async ()
       }
       return secondRead.promise
     },
-    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number) {
-      await updateDecorations(uid, generation)
+    async 'Viewlet.executeViewletCommand'(_viewletId: number, _command: string, generation: number, ignoredUris: readonly string[]) {
+      await updateDecorations(uid, generation, ignoredUris)
     },
   })
   const firstItem = { depth: 1, name: 'first.log', path: '/workspace/first.log', selected: false, type: DirentType.File }


### PR DESCRIPTION
## Summary

- render newly read Explorer children before waiting for .gitignore decoration reads
- apply decoration results only while the captured root and item generation are current
- render valid late decoration updates without blocking subsequent Explorer commands

## Validation

- npm test
- npm run type-check
- npm run lint
- npm run build