### PR TITLE
fix: preserve folder type in explorer drag data

### DIFF
--- a/packages/explorer-view/src/parts/GetDragData/GetDragData.ts
+++ b/packages/explorer-view/src/parts/GetDragData/GetDragData.ts
@@ -1,5 +1,6 @@
-import { ensureUri } from '../EnsureUris/EnsureUris.ts'
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
 import { getDragLabel } from '../GetDragLabel/GetDragLabel.ts'
+import { getDragUri } from '../GetDragUri/GetDragUri.ts'
 
 interface DragInfoItem {
   readonly data: string
@@ -11,8 +12,8 @@ export interface IDragInfoNew {
   readonly label?: string
 }
 
-export const getDragData = (urls: readonly string[]): IDragInfoNew => {
-  const data = urls.map(ensureUri).join('\n')
+export const getDragData = (items: readonly Pick<ExplorerItem, 'path' | 'type'>[]): IDragInfoNew => {
+  const data = items.map(getDragUri).join('\n')
   const dragData: readonly DragInfoItem[] = [
     {
       data,
@@ -25,6 +26,6 @@ export const getDragData = (urls: readonly string[]): IDragInfoNew => {
   ]
   return {
     items: dragData,
-    label: getDragLabel(urls),
+    label: getDragLabel(items.map((item) => item.path)),
   }
 }

--- a/packages/explorer-view/src/parts/GetDragUri/GetDragUri.ts
+++ b/packages/explorer-view/src/parts/GetDragUri/GetDragUri.ts
@@ -1,0 +1,20 @@
+import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
+import * as DirentType from '../DirentType/DirentType.ts'
+import { ensureUri } from '../EnsureUris/EnsureUris.ts'
+
+const directoryTypes = new Set([
+  DirentType.Directory,
+  DirentType.DirectoryExpanded,
+  DirentType.DirectoryExpanding,
+  DirentType.EditingDirectoryExpanded,
+  DirentType.EditingFolder,
+  DirentType.SymLinkFolder,
+])
+
+export const getDragUri = (item: Pick<ExplorerItem, 'path' | 'type'>): string => {
+  const uri = ensureUri(item.path)
+  if (directoryTypes.has(item.type) && !uri.endsWith('/')) {
+    return `${uri}/`
+  }
+  return uri
+}

--- a/packages/explorer-view/src/parts/GetInternalDragPaths/GetInternalDragPaths.ts
+++ b/packages/explorer-view/src/parts/GetInternalDragPaths/GetInternalDragPaths.ts
@@ -1,11 +1,11 @@
 import type { ExplorerItem } from '../ExplorerItem/ExplorerItem.ts'
-import { ensureUri } from '../EnsureUris/EnsureUris.ts'
+import { getDragUri } from '../GetDragUri/GetDragUri.ts'
 
 export const getInternalDragPaths = (items: readonly ExplorerItem[], uris: readonly string[]): readonly string[] => {
   if (uris.length === 0) {
     return []
   }
-  const pathByUri = new Map(items.map((item) => [ensureUri(item.path), item.path]))
+  const pathByUri = new Map(items.map((item) => [getDragUri(item), item.path]))
   const paths: string[] = []
   for (const uri of uris) {
     const path = pathByUri.get(uri)

--- a/packages/explorer-view/src/parts/RenderDragData/RenderDragData.ts
+++ b/packages/explorer-view/src/parts/RenderDragData/RenderDragData.ts
@@ -16,6 +16,6 @@ export const renderDragData = (oldState: ExplorerState, newState: ExplorerState)
   } else {
     draggedItems = []
   }
-  const dragData = getDragData(draggedItems.map((item) => item.path))
+  const dragData = getDragData(draggedItems)
   return ['Viewlet.setDragData', uid, dragData]
 }

--- a/packages/explorer-view/test/GetDragData.test.ts
+++ b/packages/explorer-view/test/GetDragData.test.ts
@@ -1,32 +1,39 @@
 import { test, expect } from '@jest/globals'
+import * as DirentType from '../src/parts/DirentType/DirentType.js'
 import { getDragData } from '../src/parts/GetDragData/GetDragData.js'
 
 test('getDragData - single url', () => {
-  const urls: string[] = ['/a.txt']
-  const result = getDragData(urls)
+  const result = getDragData([{ path: '/a.txt', type: DirentType.File }])
   expect(result.items[0]).toEqual({ data: 'file:///a.txt', type: 'text/uri-list' })
   expect(result.items[1]).toEqual({ data: 'file:///a.txt', type: 'text/plain' })
   expect(result.label).toBe('a.txt')
 })
 
 test('getDragData - multiple urls', () => {
-  const urls: string[] = ['/a.txt', '/b.txt']
-  const result = getDragData(urls)
+  const result = getDragData([
+    { path: '/a.txt', type: DirentType.File },
+    { path: '/b.txt', type: DirentType.File },
+  ])
   expect(result.items[0]).toEqual({ data: 'file:///a.txt\nfile:///b.txt', type: 'text/uri-list' })
   expect(result.items[1]).toEqual({ data: 'file:///a.txt\nfile:///b.txt', type: 'text/plain' })
   expect(result.label).toBe('2')
 })
 
 test('getDragData - empty', () => {
-  const urls: string[] = []
-  const result = getDragData(urls)
+  const result = getDragData([])
   expect(result.items[0]).toEqual({ data: '', type: 'text/uri-list' })
   expect(result.items[1]).toEqual({ data: '', type: 'text/plain' })
   expect(result.label).toBe('0')
 })
 
 test('getDragData - preserves non-file workspace uri', () => {
-  const result = getDragData(['memfs:///workspace/Main.elm'])
+  const result = getDragData([{ path: 'memfs:///workspace/Main.elm', type: DirentType.File }])
 
   expect(result.items[0]).toEqual({ data: 'memfs:///workspace/Main.elm', type: 'text/uri-list' })
+})
+
+test('getDragData - marks remote folders with a trailing slash', () => {
+  const result = getDragData([{ path: 'remote-ssh://test-host/workspace/src', type: DirentType.Directory }])
+
+  expect(result.items[0]).toEqual({ data: 'remote-ssh://test-host/workspace/src/', type: 'text/uri-list' })
 })

--- a/packages/explorer-view/test/GetInternalDragPaths.test.ts
+++ b/packages/explorer-view/test/GetInternalDragPaths.test.ts
@@ -20,6 +20,14 @@ test('preserves non-file workspace uris', () => {
   expect(getInternalDragPaths(memoryItems, ['memfs:///workspace/Main.elm'])).toEqual(['memfs:///workspace/Main.elm'])
 })
 
+test('matches a remote folder uri with a trailing slash', () => {
+  const remoteItems: readonly ExplorerItem[] = [
+    { depth: 1, name: 'src', path: 'remote-ssh://test-host/workspace/src', selected: false, type: DirentType.Directory },
+  ]
+
+  expect(getInternalDragPaths(remoteItems, ['remote-ssh://test-host/workspace/src/'])).toEqual(['remote-ssh://test-host/workspace/src'])
+})
+
 test('rejects a partially external uri list', () => {
   expect(getInternalDragPaths(items, ['file:///workspace/Main.elm', 'file:///tmp/external.txt'])).toEqual([])
 })

--- a/packages/explorer-view/test/RenderDragData.test.ts
+++ b/packages/explorer-view/test/RenderDragData.test.ts
@@ -119,6 +119,41 @@ test('renderDragData - only pointed item when pointing outside the selection', (
   ])
 })
 
+test('renderDragData - remote folder has a trailing slash', () => {
+  const oldState: ExplorerState = createDefaultState()
+  const newState: ExplorerState = {
+    ...oldState,
+    focusedIndex: 0,
+    isPointerDown: true,
+    items: [
+      {
+        depth: 1,
+        icon: '',
+        name: 'src',
+        path: 'remote-ssh://test-host/workspace/src',
+        posInSet: 1,
+        selected: false,
+        setSize: 1,
+        type: DirentType.Directory,
+      },
+    ],
+    pointerDownIndex: 0,
+    uid: 123,
+  }
+
+  expect(renderDragData(oldState, newState)).toEqual([
+    'Viewlet.setDragData',
+    123,
+    {
+      items: [
+        { data: 'remote-ssh://test-host/workspace/src/', type: 'text/uri-list' },
+        { data: 'remote-ssh://test-host/workspace/src/', type: 'text/plain' },
+      ],
+      label: 'src',
+    },
+  ])
+})
+
 test('renderDragData - no item for an out-of-range pointer index', () => {
   const oldState: ExplorerState = createDefaultState()
   const newState: ExplorerState = {


### PR DESCRIPTION
## Summary
- mark Explorer directories with a trailing slash in drag URI lists
- preserve URI schemes such as remote-ssh instead of relying on filesystem stat
- keep internal Explorer drag path resolution compatible with directory URIs

## Root cause
Explorer discarded the known directory type when producing drag data. Main area therefore attempted FileSystem.stat, but Remote SSH does not expose stat, so the folder was opened as an editor and failed with EISDIR.

## Tests
- npm run type-check
- npm run lint
- npm run build
- npm test -- --runInBand (237 suites, 966 tests passed)