### PR TITLE
feature: handle view events directly

### DIFF
--- a/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
+++ b/packages/explorer-view/src/parts/CommandMap/CommandMap.ts
@@ -91,6 +91,8 @@ import * as ToggleIndividualSelection from '../ToggleIndividualSelection/ToggleI
 import * as UpdateEditingValue from '../UpdateEditingValue/UpdateEditingValue.ts'
 import * as UpdateIcons from '../UpdateIcons/UpdateIcons.ts'
 
+const handleDirectMessagePort = (port: MessagePort): Promise<void> => HandleMessagePort.handleMessagePort(port, commandMap)
+
 export const commandMap = {
   'Explorer.acceptEdit': WrapCommand.wrapListItemCommand(AcceptEdit.acceptEdit),
   'Explorer.cancelEdit': WrapCommand.wrapListItemCommand(CancelEdit.cancelEdit),
@@ -147,7 +149,7 @@ export const commandMap = {
   'Explorer.handleInputClick': WrapCommand.wrapListItemCommand(HandleInputClick.handleInputClick),
   'Explorer.handleInputKeyDown': WrapCommand.wrapListItemCommand(HandleInputKeyDown.handleInputKeyDown),
   'Explorer.handleKeyDown': WrapCommand.wrapListItemCommand(HandleKeyDown.handleKeyDown),
-  'Explorer.handleMessagePort': HandleMessagePort.handleMessagePort,
+  'Explorer.handleMessagePort': handleDirectMessagePort,
   'Explorer.handleNativePaste': WrapCommand.wrapListItemCommand(HandleNativePaste.handleNativePaste),
   'Explorer.handlePaste': WrapCommand.wrapListItemCommand(HandlePaste.handlePaste),
   'Explorer.handlePointerDown': WrapCommand.wrapListItemCommand(HandlePointerDown.handlePointerDown),

--- a/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
+++ b/packages/explorer-view/src/parts/HandleMessagePort/HandleMessagePort.ts
@@ -1,9 +1,21 @@
 import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
-export const handleMessagePort = async (port: MessagePort): Promise<void> => {
+export const handleMessagePort = async (port: MessagePort, viewletCommandMap: Readonly<Record<string, unknown>>): Promise<void> => {
+  const executeViewletCommand = async (uid: number, command: string, ...args: readonly any[]): Promise<void> => {
+    const fn = viewletCommandMap[`Explorer.${command}`]
+    if (typeof fn !== 'function') {
+      throw new TypeError(`Viewlet command not found: ${command}`)
+    }
+    await fn(uid, ...args)
+    await RendererWorker.invoke('Viewlet.requestRender', uid)
+  }
+
   const rpc = await PlainMessagePortRpc.create({
-    commandMap: {},
+    commandMap: {
+      'Viewlet.executeViewletCommand': executeViewletCommand,
+    },
     messagePort: port,
   })
   RendererProcess.set(rpc)

--- a/packages/explorer-view/test/HandleMessagePort.test.ts
+++ b/packages/explorer-view/test/HandleMessagePort.test.ts
@@ -1,22 +1,42 @@
 import { expect, jest, test } from '@jest/globals'
-import { PlainMessagePortRpcParent } from '@lvce-editor/rpc'
-import { RendererProcess } from '@lvce-editor/rpc-registry'
+import { createMockRpc, PlainMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererProcess as RendererProcessRegistry, RendererWorker } from '@lvce-editor/rpc-registry'
 import { handleMessagePort } from '../src/parts/HandleMessagePort/HandleMessagePort.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 
-test('handleMessagePort connects the explorer worker to the renderer process', async () => {
+test('connects the view directly to the renderer process', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 31)
   const { port1, port2 } = new MessageChannel()
   const rendererProcessRpc = await PlainMessagePortRpcParent.create({
-    commandMap: {
-      'Viewlet.queueCommands': queueCommands,
-    },
+    commandMap: { 'Viewlet.queueCommands': queueCommands },
     messagePort: port1,
   })
+  const handleEvent = jest.fn(async (_uid: number, _value: string) => {})
 
-  await handleMessagePort(port2)
+  await handleMessagePort(port2, {
+    'Explorer.handleEvent': handleEvent,
+  })
+  expect(RendererProcess.isConnected()).toBe(true)
   await expect(RendererProcess.invoke('Viewlet.queueCommands', 7, [['Viewlet.setDom2', 7, []]])).resolves.toBe(31)
   expect(queueCommands).toHaveBeenCalledWith(7, [['Viewlet.setDom2', 7, []]])
 
-  await RendererProcess.dispose()
+  const requestRender = jest.fn(async (_uid: number) => {})
+  RendererWorker.set(
+    Object.assign(
+      createMockRpc({
+        commandMap: {
+          'Viewlet.requestRender': requestRender,
+        },
+      }),
+      { dispose: jest.fn() },
+    ),
+  )
+  await rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'handleEvent', 'hello')
+  expect(handleEvent).toHaveBeenCalledWith(7, 'hello')
+  expect(requestRender).toHaveBeenCalledWith(7)
+  await expect(rendererProcessRpc.invoke('Viewlet.executeViewletCommand', 7, 'missing')).rejects.toThrow('Viewlet command not found: missing')
+
+  await RendererProcessRegistry.dispose()
+  await RendererWorker.dispose()
   await rendererProcessRpc.dispose()
 })


### PR DESCRIPTION
## Summary
- expose direct renderer-process DOM event handling on the view port
- update view state in the owning worker and request a renderer-worker diff/render
- defer command-map capture until the direct port is connected

## Tests
- npm run type-check
- focused direct message-port test
- full repository test suite