### PR TITLE
feature: publish explorer settings contribution

### DIFF
--- a/packages/build/src/build.ts
+++ b/packages/build/src/build.ts
@@ -72,3 +72,4 @@ await writeJson(join(dist, 'package.json'), packageJson)
 
 await cp(join(root, 'README.md'), join(dist, 'README.md'))
 await cp(join(root, 'LICENSE'), join(dist, 'LICENSE'))
+await cp(join(root, 'packages', 'explorer-view', 'settings.json'), join(dist, 'dist', 'settings.json'))

--- a/packages/explorer-view/settings.json
+++ b/packages/explorer-view/settings.json
@@ -1,0 +1,56 @@
+[
+  {
+    "category": "explorer",
+    "description": "Controls whether the Explorer uses chevrons instead of folder icons to show expanded and collapsed folders.",
+    "heading": "Use Chevrons",
+    "id": "explorer.useChevrons",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "explorer",
+    "description": "Controls whether the Explorer asks for confirmation before deleting files and folders.",
+    "heading": "Confirm Delete",
+    "id": "explorer.confirmdelete",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "explorer",
+    "description": "Controls whether the Explorer asks for confirmation before pasting files and folders.",
+    "heading": "Confirm Paste",
+    "id": "explorer.confirmpaste",
+    "type": 3,
+    "value": "false"
+  },
+  {
+    "category": "explorer",
+    "description": "Controls whether files ignored by Git are decorated in the Explorer.",
+    "heading": "Git Ignore Decorations",
+    "id": "explorer.gitIgnoreDecorations",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "explorer",
+    "description": "Controls whether source control decorations are shown in the Explorer.",
+    "heading": "Source Control Decorations",
+    "id": "explorer.sourceControlDecorations",
+    "type": 3,
+    "value": "true"
+  },
+  {
+    "category": "explorer",
+    "description": "Configures glob patterns for excluding files and folders from the Explorer.",
+    "heading": "Exclude",
+    "id": "files.exclude",
+    "type": 4,
+    "value": {
+      "**/.DS_Store": true,
+      "**/.git": true,
+      "**/.hg": true,
+      "**/.svn": true,
+      "**/Thumbs.db": true
+    }
+  }
+]


### PR DESCRIPTION
Publishes Explorer-owned setting metadata and copies it beside the packaged worker artifact.