### PR TITLE
fix: schedule explorer drag data rendering

### DIFF
--- a/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
+++ b/packages/explorer-view/src/parts/ExplorerStates/ExplorerStates.ts
@@ -76,6 +76,10 @@ const hasSameVisibleExplorerItemInputs = (oldState: ExplorerState, newState: Exp
   )
 }
 
+const hasSameDragDataInputs = (oldState: ExplorerState, newState: ExplorerState): boolean => {
+  return oldState.isPointerDown === newState.isPointerDown && oldState.pointerDownIndex === newState.pointerDownIndex
+}
+
 export const updateGitIgnoredUris = (state: ExplorerState, generation: number, sourceControlIgnoredUris: readonly string[]): ExplorerState => {
   const { gitIgnoreGeneration } = state
   if (gitIgnoreGeneration !== generation) {
@@ -172,7 +176,7 @@ const wrapListItemCommandInternal = <T extends any[]>(fn: Fn<T>, queued: boolean
     const intermediate = get(id)
     set(id, intermediate.oldState, updatedState, intermediate.scheduledState)
     if (hasSameVisibleExplorerItemInputs(intermediate.newState, updatedState)) {
-      if (updatedState.inputSource === InputSource.User) {
+      if (updatedState.inputSource === InputSource.User || !hasSameDragDataInputs(intermediate.newState, updatedState)) {
         set(id, intermediate.oldState, updatedState)
       }
       return {

--- a/packages/explorer-view/test/ExplorerStates.test.ts
+++ b/packages/explorer-view/test/ExplorerStates.test.ts
@@ -196,6 +196,25 @@ test('wrapListItemCommand preserves user input when a pending render commits', a
   expect(newState.editingValue).toBe('new.txt')
 })
 
+test('wrapListItemCommand schedules drag state changes for rendering', async () => {
+  const uid = 9011
+  const state = createDefaultState()
+  const wrapped = ExplorerStates.wrapListItemCommand(async (currentState) => {
+    return {
+      ...currentState,
+      isPointerDown: true,
+      pointerDownIndex: 2,
+    }
+  })
+
+  ExplorerStates.set(uid, state, state)
+  await wrapped(uid)
+
+  const { scheduledState } = ExplorerStates.get(uid)
+  expect(scheduledState.isPointerDown).toBe(true)
+  expect(scheduledState.pointerDownIndex).toBe(2)
+})
+
 test('wrapListItemCommandImmediate allows a callback while a queued command is running', async () => {
   const uid = 9004
   const state = createDefaultState()


### PR DESCRIPTION
- render Explorer pointer-down state even when visible rows are unchanged
- ensure Explorer URI drag data reaches the main-area drop handler