### PR TITLE
feature: use drop sessions for explorer drops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,10 +2932,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.16.0.tgz",
-      "integrity": "sha512-YCrIuadsm/gsRi2aX3RBj5cvPNUqWX7rENkpFHU1kMooDXv10CNcuJBQJqt/vFZfFp6UKI1bSyBBZV5PGQYebQ==",
-      "dev": true,
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.18.0.tgz",
+      "integrity": "sha512-PkiMJEJg3uNWfQbowU/CrKO33FORN019/C76gYFn6B0DJjYul+IwiA3RnnO/4M9ETA3fFmAs0BCpk4erpgLLhA==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3078,10 +3077,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.100.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.100.25.tgz",
-      "integrity": "sha512-8nVck1sTzVlzbHbetp0RNoTAoqzkqc5QCD+Nj3fbdCvKHn5wd1R7DiMpUjCcMnxMs9v1OqZUHqVfoEKqRNtoTg==",
-      "dev": true,
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.5.tgz",
+      "integrity": "sha512-rLhiJLg+lMQLvyrjkqoG729PgB2cTldYaFM3nSQ+4OBAS3ZnDo66e4U0riKwX9tzNfF2AwzwMYj/fJsQYBSnKw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3094,10 +3092,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.14.0.tgz",
-      "integrity": "sha512-zDkSEAUi5IsWqAqAwWtAN+AnuPr/6ZG0nrB5kLhT9i3P/TvODMB02DFVs3XgSQF+8i0QeAFkpfu78nhRb7RoNQ==",
-      "dev": true,
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.15.1.tgz",
+      "integrity": "sha512-/95YKbAlyPynnNfjjYSeadBkDJKzPjG308n9iEp9iAbG7Vjbp26yT/MLbS5xmnvWxiHiKl7r5d20nPRdUWYfOA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3136,9 +3133,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.11.0.tgz",
-      "integrity": "sha512-+P1E4Oi1RF/UoJQba2v4Q3E/s6L6ubJOJ2u8jASG/KSijBf12OWKnIxwJBKQtyKXVnay5kE4HNMciqaNVrJZmg==",
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.12.0.tgz",
+      "integrity": "sha512-HIvnQXJafvzMxvT5wzr+14IT4hzD1RhjpgmtWni4NrR5QbVvzH+SfgwudjKZW5iNXY2jjWQb1ZU6Hqu4BR3f/Q==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3151,9 +3148,9 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
-      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.7.0.tgz",
+      "integrity": "sha512-31bqdXnEKSXDYWcULk0IeBP2jXXfb64R5ScfmiJolhs5r/SPdeKqu8CfqESHpOuyrN1Gq61sgG/2HCwnkAgfIA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -3707,10 +3704,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
-      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
-      "dev": true,
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.19.0.tgz",
+      "integrity": "sha512-9mTXcgXUfqObo5IayArwI4+xXcphi1e05SpZyoG6w0Vk/KFvhWKsKu+ML/Oc3TCgYEEzpvjlghYRMXN9epkGuw==",
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -3723,10 +3719,9 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
-      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
-      "dev": true,
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.8.0.tgz",
+      "integrity": "sha512-xyT/6W5l9+T/zZx/PLF8sgaOOI6ywiteUnJ5rBDC6BBhCSH/VtgodJ6V1CF761eq4bVx01fF5iaUSqYdK75T6g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3766,14 +3761,13 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.51.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.51.0.tgz",
-      "integrity": "sha512-N8HWyjINBTako+zUsFjJ8C8UBC1OUjXnwAC8AkAiZ8WDkRSJw/eQAS+tQxxCKnPYoo8YZ8Qf/q3W4Hjp9bfhAQ==",
-      "dev": true,
+      "version": "9.52.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.52.0.tgz",
+      "integrity": "sha512-J2DI4hv9jH/aidMeoGpJVGms3yOPcgF/KdrTcIlH3ZutgqHuV5+/u7cbI3tIm/ZkBwuL2zzYZnC4y9qVwM5CoA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.27.0",
+        "@lvce-editor/constants": "^5.28.0",
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
@@ -3937,115 +3931,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/embeds-process": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.18.0.tgz",
-      "integrity": "sha512-PkiMJEJg3uNWfQbowU/CrKO33FORN019/C76gYFn6B0DJjYul+IwiA3RnnO/4M9ETA3fFmAs0BCpk4erpgLLhA==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "embeds-process": "bin/embedsProcess.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.5.tgz",
-      "integrity": "sha512-rLhiJLg+lMQLvyrjkqoG729PgB2cTldYaFM3nSQ+4OBAS3ZnDo66e4U0riKwX9tzNfF2AwzwMYj/fJsQYBSnKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/rpc": "^6.18.0",
-        "@lvce-editor/verror": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-system-process": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.15.1.tgz",
-      "integrity": "sha512-/95YKbAlyPynnNfjjYSeadBkDJKzPjG308n9iEp9iAbG7Vjbp26yT/MLbS5xmnvWxiHiKl7r5d20nPRdUWYfOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "trash": "^10.1.1",
-        "ws": "^8.21.1"
-      },
-      "bin": {
-        "file-system-process": "bin/fileSystemProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/ipc": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.12.0.tgz",
-      "integrity": "sha512-HIvnQXJafvzMxvT5wzr+14IT4hzD1RhjpgmtWni4NrR5QbVvzH+SfgwudjKZW5iNXY2jjWQb1ZU6Hqu4BR3f/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0",
-        "ws": "^8.21.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.7.0.tgz",
-      "integrity": "sha512-31bqdXnEKSXDYWcULk0IeBP2jXXfb64R5ScfmiJolhs5r/SPdeKqu8CfqESHpOuyrN1Gq61sgG/2HCwnkAgfIA==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/process-explorer": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.19.0.tgz",
-      "integrity": "sha512-9mTXcgXUfqObo5IayArwI4+xXcphi1e05SpZyoG6w0Vk/KFvhWKsKu+ML/Oc3TCgYEEzpvjlghYRMXN9epkGuw==",
-      "license": "MIT",
-      "bin": {
-        "process-explorer": "bin/processExplorer.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@vscode/windows-process-tree": "^0.8.0"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/pty-host": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.8.0.tgz",
-      "integrity": "sha512-xyT/6W5l9+T/zZx/PLF8sgaOOI6ywiteUnJ5rBDC6BBhCSH/VtgodJ6V1CF761eq4bVx01fF5iaUSqYdK75T6g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@lvce-editor/command": "^2.0.0"
-      },
-      "bin": {
-        "pty-host": "bin/ptyHost.js"
-      },
-      "optionalDependencies": {
-        "node-pty": "1.1.0-beta34"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.52.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.52.0.tgz",
-      "integrity": "sha512-J2DI4hv9jH/aidMeoGpJVGms3yOPcgF/KdrTcIlH3ZutgqHuV5+/u7cbI3tIm/ZkBwuL2zzYZnC4y9qVwM5CoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.28.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+    "node_modules/@lvce-editor/shared-process": {
       "version": "0.105.5",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.5.tgz",
       "integrity": "sha512-LEqk3NuyEf5OwJgmQPm+PGmASUtJKgChin5UFknJFNshf49tkC85GIMTOMRDUttokGDgsX5C2xl7+pzXlny0Bg==",
@@ -4084,72 +3970,10 @@
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/static-server": {
+    "node_modules/@lvce-editor/static-server": {
       "version": "0.105.5",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.5.tgz",
       "integrity": "sha512-PzQOikbFCfrlnpL6pnLCcFWW/ub5NHZjN7rpHbxCBxWcMh7keYug2qxH+6eyHGJHF7KslK0TfGs4Blp5kyHUMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.10.1.tgz",
-      "integrity": "sha512-Drqz1w+Z4Pyp6BYC2hNGiMJExtGxy8VlwoO5C1PbWTumrvvnBK/9dTricH2llXlQl8VXGGAXXw1p2GxrUCxtRw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "typescript-compile-process": "bin/typescriptCompileProcess.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process": {
-      "version": "0.100.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.100.25.tgz",
-      "integrity": "sha512-3yyBc7gZo6XCdYttYqxq6jLHNYPvhQmXNVajH2e8cE/L/KYFOTlKRAB1qdiAbNoqSVO/TR7W1WrShZ1hTLsgjQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.100.25",
-        "@lvce-editor/ipc": "16.11.0",
-        "@lvce-editor/json-rpc": "8.6.0",
-        "@lvce-editor/jsonc-parser": "1.5.0",
-        "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.14.0",
-        "@lvce-editor/rpc-registry": "9.51.0",
-        "@lvce-editor/verror": "1.7.0",
-        "is-object": "^1.0.2",
-        "markdown-it": "^15.0.0",
-        "xdg-basedir": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.16.0",
-        "@lvce-editor/file-system-process": "5.14.0",
-        "@lvce-editor/file-watcher-process": "4.13.0",
-        "@lvce-editor/network-process": "5.2.0",
-        "@lvce-editor/preload": "1.5.0",
-        "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.7.0",
-        "@lvce-editor/search-process": "15.8.0",
-        "@lvce-editor/typescript-compile-process": "5.9.0",
-        "open": "^11.0.0",
-        "tail": "^2.2.6",
-        "tmp-promise": "^3.0.3",
-        "trash": "^10.1.1"
-      }
-    },
-    "node_modules/@lvce-editor/static-server": {
-      "version": "0.100.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.100.25.tgz",
-      "integrity": "sha512-xAsuRVoRLAO6SIWt8Wu7pEbTCAFI+dj/+XQC51NfghEjxe/l6NXzy/Dz9HxDOsnT+Pg1nWvvj+2bAuK69lJu7w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -4199,10 +4023,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.9.0.tgz",
-      "integrity": "sha512-qYsKBc0FkVFshKpC88+/T3P41Xi5nx2Hb2y8Vq2DHr+ceGq7w7XTnVZBqWVe4vO7eZPLpyi3/UhdD8a8P7ADuQ==",
-      "dev": true,
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.10.1.tgz",
+      "integrity": "sha512-Drqz1w+Z4Pyp6BYC2hNGiMJExtGxy8VlwoO5C1PbWTumrvvnBK/9dTricH2llXlQl8VXGGAXXw1p2GxrUCxtRw==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -16162,8 +15985,8 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
         "@lvce-editor/measure-memory": "^3.11.0",
-        "@lvce-editor/shared-process": "0.100.25",
-        "@lvce-editor/static-server": "0.100.25",
+        "@lvce-editor/shared-process": "0.105.5",
+        "@lvce-editor/static-server": "0.105.5",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^25.5.0",
@@ -16238,15 +16061,6 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
-      }
-    },
-    "packages/server/node_modules/@lvce-editor/static-server": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.5.tgz",
-      "integrity": "sha512-PzQOikbFCfrlnpL6pnLCcFWW/ub5NHZjN7rpHbxCBxWcMh7keYug2qxH+6eyHGJHF7KslK0TfGs4Blp5kyHUMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
       }
     },
     "packages/server/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4039,6 +4039,7 @@
       "version": "0.105.9",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.9.tgz",
       "integrity": "sha512-hQeQIfDUHmWg4XmxzfK7nO/0mCHlS8lJZLjrZI10Qny33t59nSHUOZTxAVavsHygZu1I4/ipoJ+J+S0N0of3yw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -16122,10 +16123,19 @@
       "dependencies": {
         "@lvce-editor/drag-and-drop-worker": "0.6.0",
         "@lvce-editor/server": "0.105.14",
-        "@lvce-editor/static-server": "0.105.9"
+        "@lvce-editor/static-server": "0.105.14"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/static-server": {
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.14.tgz",
+      "integrity": "sha512-m0y2Nmmubj0Bos1KyRuQ+Qipsu5f1aDdECvzqRM5upkjWMvyvgMMlvU2nSehJxfiGkYK0+auR08LQLsmwQfzqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
       }
     },
     "packages/server/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2900,6 +2900,19 @@
       "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.17.0.tgz",
+      "integrity": "sha512-b9PDgPqIuyEh+tq8M+MXaj7gzcpaHBr+hvl+tigdbfW3t5rmfNhGbzOI0lFBAtYUfGrHewbnlFXQY4Giq/GTJQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
@@ -2913,15 +2926,16 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/drag-and-drop-worker": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/drag-and-drop-worker/-/drag-and-drop-worker-0.4.0.tgz",
-      "integrity": "sha512-1LmjteLStAvmeOA4cgvBVU6rlZFrSJsIDiYVN+LsM8uy5m0vIjH4LQ2CBlYoHsXrlRl0iQt5Gf7zzBXHAuVALQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/drag-and-drop-worker/-/drag-and-drop-worker-0.6.0.tgz",
+      "integrity": "sha512-u7rlCaC+JY2Vg7iWeHQLBRzsOju8S3p5sgS4XEIoABbknLYZ9A5rNKiyfhrUKq4uqyVNaMQ+Gp8nFVUD0P4Iaw==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
       "version": "4.16.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.16.0.tgz",
       "integrity": "sha512-YCrIuadsm/gsRi2aX3RBj5cvPNUqWX7rENkpFHU1kMooDXv10CNcuJBQJqt/vFZfFp6UKI1bSyBBZV5PGQYebQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3067,6 +3081,7 @@
       "version": "0.100.25",
       "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.100.25.tgz",
       "integrity": "sha512-8nVck1sTzVlzbHbetp0RNoTAoqzkqc5QCD+Nj3fbdCvKHn5wd1R7DiMpUjCcMnxMs9v1OqZUHqVfoEKqRNtoTg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3082,6 +3097,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.14.0.tgz",
       "integrity": "sha512-zDkSEAUi5IsWqAqAwWtAN+AnuPr/6ZG0nrB5kLhT9i3P/TvODMB02DFVs3XgSQF+8i0QeAFkpfu78nhRb7RoNQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3694,6 +3710,7 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
       "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "process-explorer": "bin/processExplorer.js"
@@ -3709,6 +3726,7 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
       "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3751,6 +3769,7 @@
       "version": "9.51.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.51.0.tgz",
       "integrity": "sha512-N8HWyjINBTako+zUsFjJ8C8UBC1OUjXnwAC8AkAiZ8WDkRSJw/eQAS+tQxxCKnPYoo8YZ8Qf/q3W4Hjp9bfhAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3902,13 +3921,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.100.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.100.25.tgz",
-      "integrity": "sha512-iRTVKNxwchqpO9r5zByLasnNdW7ktMd/Ap6sUB+iVTJeAugJQXC6I4hFy3Dji3fRWLJCjEK5+7i0VqkwTu7mgA==",
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.5.tgz",
+      "integrity": "sha512-jgTHyU/QEbxQ8UPYY68kgP/VfFk/nqgxBnUCYOasiMax1ojeuqz4qycuY+wFIF8jz+CSEGhboEp9MyEDhLlhIQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.100.25",
-        "@lvce-editor/static-server": "0.100.25"
+        "@lvce-editor/jsonc-parser": "^1.5.0",
+        "@lvce-editor/shared-process": "0.105.5",
+        "@lvce-editor/static-server": "0.105.5"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3917,10 +3937,180 @@
         "node": ">=24"
       }
     },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/embeds-process": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.18.0.tgz",
+      "integrity": "sha512-PkiMJEJg3uNWfQbowU/CrKO33FORN019/C76gYFn6B0DJjYul+IwiA3RnnO/4M9ETA3fFmAs0BCpk4erpgLLhA==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "embeds-process": "bin/embedsProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.5.tgz",
+      "integrity": "sha512-rLhiJLg+lMQLvyrjkqoG729PgB2cTldYaFM3nSQ+4OBAS3ZnDo66e4U0riKwX9tzNfF2AwzwMYj/fJsQYBSnKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.18.0",
+        "@lvce-editor/verror": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-system-process": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.15.1.tgz",
+      "integrity": "sha512-/95YKbAlyPynnNfjjYSeadBkDJKzPjG308n9iEp9iAbG7Vjbp26yT/MLbS5xmnvWxiHiKl7r5d20nPRdUWYfOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "trash": "^10.1.1",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "file-system-process": "bin/fileSystemProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/ipc": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.12.0.tgz",
+      "integrity": "sha512-HIvnQXJafvzMxvT5wzr+14IT4hzD1RhjpgmtWni4NrR5QbVvzH+SfgwudjKZW5iNXY2jjWQb1ZU6Hqu4BR3f/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.7.0.tgz",
+      "integrity": "sha512-31bqdXnEKSXDYWcULk0IeBP2jXXfb64R5ScfmiJolhs5r/SPdeKqu8CfqESHpOuyrN1Gq61sgG/2HCwnkAgfIA==",
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/process-explorer": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.19.0.tgz",
+      "integrity": "sha512-9mTXcgXUfqObo5IayArwI4+xXcphi1e05SpZyoG6w0Vk/KFvhWKsKu+ML/Oc3TCgYEEzpvjlghYRMXN9epkGuw==",
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/pty-host": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.8.0.tgz",
+      "integrity": "sha512-xyT/6W5l9+T/zZx/PLF8sgaOOI6ywiteUnJ5rBDC6BBhCSH/VtgodJ6V1CF761eq4bVx01fF5iaUSqYdK75T6g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
+      "bin": {
+        "pty-host": "bin/ptyHost.js"
+      },
+      "optionalDependencies": {
+        "node-pty": "1.1.0-beta34"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.52.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.52.0.tgz",
+      "integrity": "sha512-J2DI4hv9jH/aidMeoGpJVGms3yOPcgF/KdrTcIlH3ZutgqHuV5+/u7cbI3tIm/ZkBwuL2zzYZnC4y9qVwM5CoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.28.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.5.tgz",
+      "integrity": "sha512-LEqk3NuyEf5OwJgmQPm+PGmASUtJKgChin5UFknJFNshf49tkC85GIMTOMRDUttokGDgsX5C2xl7+pzXlny0Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.105.5",
+        "@lvce-editor/ipc": "16.12.0",
+        "@lvce-editor/json-rpc": "8.7.0",
+        "@lvce-editor/jsonc-parser": "1.5.0",
+        "@lvce-editor/pretty-error": "2.0.0",
+        "@lvce-editor/process-explorer": "3.19.0",
+        "@lvce-editor/rpc-registry": "9.52.0",
+        "@lvce-editor/verror": "1.7.0",
+        "is-object": "^1.0.2",
+        "markdown-it": "^15.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/auth-process": "1.17.0",
+        "@lvce-editor/embeds-process": "4.18.0",
+        "@lvce-editor/file-system-process": "5.15.1",
+        "@lvce-editor/file-watcher-process": "4.13.0",
+        "@lvce-editor/network-process": "5.2.0",
+        "@lvce-editor/preload": "1.5.0",
+        "@lvce-editor/preview-process": "11.0.0",
+        "@lvce-editor/pty-host": "8.8.0",
+        "@lvce-editor/search-process": "15.8.0",
+        "@lvce-editor/typescript-compile-process": "5.10.1",
+        "open": "^11.0.1",
+        "tail": "^2.2.6",
+        "tmp-promise": "^3.0.3",
+        "trash": "^10.1.1"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/static-server": {
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.5.tgz",
+      "integrity": "sha512-PzQOikbFCfrlnpL6pnLCcFWW/ub5NHZjN7rpHbxCBxWcMh7keYug2qxH+6eyHGJHF7KslK0TfGs4Blp5kyHUMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/typescript-compile-process": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.10.1.tgz",
+      "integrity": "sha512-Drqz1w+Z4Pyp6BYC2hNGiMJExtGxy8VlwoO5C1PbWTumrvvnBK/9dTricH2llXlQl8VXGGAXXw1p2GxrUCxtRw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "typescript-compile-process": "bin/typescriptCompileProcess.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@lvce-editor/shared-process": {
       "version": "0.100.25",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.100.25.tgz",
       "integrity": "sha512-3yyBc7gZo6XCdYttYqxq6jLHNYPvhQmXNVajH2e8cE/L/KYFOTlKRAB1qdiAbNoqSVO/TR7W1WrShZ1hTLsgjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
@@ -3959,6 +4149,7 @@
       "version": "0.100.25",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.100.25.tgz",
       "integrity": "sha512-xAsuRVoRLAO6SIWt8Wu7pEbTCAFI+dj/+XQC51NfghEjxe/l6NXzy/Dz9HxDOsnT+Pg1nWvvj+2bAuK69lJu7w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -4011,6 +4202,7 @@
       "version": "5.9.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.9.0.tgz",
       "integrity": "sha512-qYsKBc0FkVFshKpC88+/T3P41Xi5nx2Hb2y8Vq2DHr+ceGq7w7XTnVZBqWVe4vO7eZPLpyi3/UhdD8a8P7ADuQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -13321,9 +13513,9 @@
       }
     },
     "node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
+      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13331,8 +13523,8 @@
         "define-lazy-prop": "^3.0.0",
         "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -13925,9 +14117,9 @@
       }
     },
     "node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14974,19 +15166,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/trash/node_modules/powershell-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/trash/node_modules/wsl-utils": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.4.0.tgz",
@@ -15791,15 +15970,28 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
       },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -16040,12 +16232,21 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/drag-and-drop-worker": "0.4.0",
-        "@lvce-editor/server": "0.100.25",
-        "@lvce-editor/static-server": "0.100.25"
+        "@lvce-editor/drag-and-drop-worker": "0.6.0",
+        "@lvce-editor/server": "0.105.5",
+        "@lvce-editor/static-server": "0.105.5"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
+      }
+    },
+    "packages/server/node_modules/@lvce-editor/static-server": {
+      "version": "0.105.5",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.5.tgz",
+      "integrity": "sha512-PzQOikbFCfrlnpL6pnLCcFWW/ub5NHZjN7rpHbxCBxWcMh7keYug2qxH+6eyHGJHF7KslK0TfGs4Blp5kyHUMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
       }
     },
     "packages/server/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3077,9 +3077,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.5.tgz",
-      "integrity": "sha512-rLhiJLg+lMQLvyrjkqoG729PgB2cTldYaFM3nSQ+4OBAS3ZnDo66e4U0riKwX9tzNfF2AwzwMYj/fJsQYBSnKw==",
+      "version": "0.105.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.8.tgz",
+      "integrity": "sha512-9PlYgGV7Ey2haPNyWkNn719Wj5OjQUwLfvDR/XTQAJTgso0wmsoa3eoDqX6E8s+6QkFKrT2FEC2mXpkFTTpH4Q==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3915,14 +3915,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.5.tgz",
-      "integrity": "sha512-jgTHyU/QEbxQ8UPYY68kgP/VfFk/nqgxBnUCYOasiMax1ojeuqz4qycuY+wFIF8jz+CSEGhboEp9MyEDhLlhIQ==",
+      "version": "0.105.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.8.tgz",
+      "integrity": "sha512-ZPB6Day6dYTZEfi8UJEBbs6MiErSYuXT7PTaTeqBNZmQHc9sg8ieqH4yawOLKiV1Z/w5ryfF3ecBWNmwz0OY1Q==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/jsonc-parser": "^1.5.0",
-        "@lvce-editor/shared-process": "0.105.5",
-        "@lvce-editor/static-server": "0.105.5"
+        "@lvce-editor/shared-process": "0.105.8",
+        "@lvce-editor/static-server": "0.105.8"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3932,13 +3932,13 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.5.tgz",
-      "integrity": "sha512-LEqk3NuyEf5OwJgmQPm+PGmASUtJKgChin5UFknJFNshf49tkC85GIMTOMRDUttokGDgsX5C2xl7+pzXlny0Bg==",
+      "version": "0.105.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.8.tgz",
+      "integrity": "sha512-RNpKSkwgY80YJkarT3/XK3GwlRUibgO5Mn41pliqU8qAJYedtklujhjokM4513At5vT2sJUiYI+uujO6TfuWew==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.105.5",
+        "@lvce-editor/extension-host-helper-process": "0.105.8",
         "@lvce-editor/ipc": "16.12.0",
         "@lvce-editor/json-rpc": "8.7.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3971,9 +3971,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.105.5",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.5.tgz",
-      "integrity": "sha512-PzQOikbFCfrlnpL6pnLCcFWW/ub5NHZjN7rpHbxCBxWcMh7keYug2qxH+6eyHGJHF7KslK0TfGs4Blp5kyHUMA==",
+      "version": "0.105.8",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.8.tgz",
+      "integrity": "sha512-gyJAlZmthuxwDflB6m4m45pK64rq1WWm5AR8MvzU87TU5TEX4pTt/kVQ+XTq5g0OioiyFziuN/zzo4xnUlZLGw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -15985,8 +15985,8 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
         "@lvce-editor/measure-memory": "^3.11.0",
-        "@lvce-editor/shared-process": "0.105.5",
-        "@lvce-editor/static-server": "0.105.5",
+        "@lvce-editor/shared-process": "0.105.8",
+        "@lvce-editor/static-server": "0.105.8",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^25.5.0",
@@ -16056,8 +16056,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/drag-and-drop-worker": "0.6.0",
-        "@lvce-editor/server": "0.105.5",
-        "@lvce-editor/static-server": "0.105.5"
+        "@lvce-editor/server": "0.105.8",
+        "@lvce-editor/static-server": "0.105.8"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3077,10 +3077,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.105.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.8.tgz",
-      "integrity": "sha512-9PlYgGV7Ey2haPNyWkNn719Wj5OjQUwLfvDR/XTQAJTgso0wmsoa3eoDqX6E8s+6QkFKrT2FEC2mXpkFTTpH4Q==",
-      "dev": true,
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.14.tgz",
+      "integrity": "sha512-hL1cqUgk7Q5PQhLAZcWOU8DD9u0x0SOQFQ7y6zXYcCY5rKnvBl/gmBCGlqZiFDB/W+Rw9nzHoWMxPnGEaCvSWw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3932,22 +3931,7 @@
         "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.105.14",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.14.tgz",
-      "integrity": "sha512-hL1cqUgk7Q5PQhLAZcWOU8DD9u0x0SOQFQ7y6zXYcCY5rKnvBl/gmBCGlqZiFDB/W+Rw9nzHoWMxPnGEaCvSWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/rpc": "^6.18.0",
-        "@lvce-editor/verror": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+    "node_modules/@lvce-editor/shared-process": {
       "version": "0.105.14",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.14.tgz",
       "integrity": "sha512-1rLXhd1hhQ6ci46UKXoN34+oSU+2rE/Gso5VoafSl+omPXi9hBaOf7lW2Cw1MeXflCCzHTfrxQCJts8/k6vmlA==",
@@ -3986,60 +3970,10 @@
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/static-server": {
+    "node_modules/@lvce-editor/static-server": {
       "version": "0.105.14",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.14.tgz",
       "integrity": "sha512-m0y2Nmmubj0Bos1KyRuQ+Qipsu5f1aDdECvzqRM5upkjWMvyvgMMlvU2nSehJxfiGkYK0+auR08LQLsmwQfzqQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process": {
-      "version": "0.105.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.8.tgz",
-      "integrity": "sha512-RNpKSkwgY80YJkarT3/XK3GwlRUibgO5Mn41pliqU8qAJYedtklujhjokM4513At5vT2sJUiYI+uujO6TfuWew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.105.8",
-        "@lvce-editor/ipc": "16.12.0",
-        "@lvce-editor/json-rpc": "8.7.0",
-        "@lvce-editor/jsonc-parser": "1.5.0",
-        "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.19.0",
-        "@lvce-editor/rpc-registry": "9.52.0",
-        "@lvce-editor/verror": "1.7.0",
-        "is-object": "^1.0.2",
-        "markdown-it": "^15.0.0",
-        "xdg-basedir": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "optionalDependencies": {
-        "@lvce-editor/auth-process": "1.17.0",
-        "@lvce-editor/embeds-process": "4.18.0",
-        "@lvce-editor/file-system-process": "5.15.1",
-        "@lvce-editor/file-watcher-process": "4.13.0",
-        "@lvce-editor/network-process": "5.2.0",
-        "@lvce-editor/preload": "1.5.0",
-        "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.8.0",
-        "@lvce-editor/search-process": "15.8.0",
-        "@lvce-editor/typescript-compile-process": "5.10.1",
-        "open": "^11.0.1",
-        "tail": "^2.2.6",
-        "tmp-promise": "^3.0.3",
-        "trash": "^10.1.1"
-      }
-    },
-    "node_modules/@lvce-editor/static-server": {
-      "version": "0.105.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.9.tgz",
-      "integrity": "sha512-hQeQIfDUHmWg4XmxzfK7nO/0mCHlS8lJZLjrZI10Qny33t59nSHUOZTxAVavsHygZu1I4/ipoJ+J+S0N0of3yw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -16051,8 +15985,8 @@
       "devDependencies": {
         "@babel/preset-typescript": "^7.29.7",
         "@lvce-editor/measure-memory": "^3.11.0",
-        "@lvce-editor/shared-process": "0.105.8",
-        "@lvce-editor/static-server": "0.105.9",
+        "@lvce-editor/shared-process": "0.105.14",
+        "@lvce-editor/static-server": "0.105.14",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^25.5.0",
@@ -16127,15 +16061,6 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.3"
-      }
-    },
-    "packages/server/node_modules/@lvce-editor/static-server": {
-      "version": "0.105.14",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.14.tgz",
-      "integrity": "sha512-m0y2Nmmubj0Bos1KyRuQ+Qipsu5f1aDdECvzqRM5upkjWMvyvgMMlvU2nSehJxfiGkYK0+auR08LQLsmwQfzqQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24"
       }
     },
     "packages/server/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,6 +3080,7 @@
       "version": "0.105.8",
       "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.8.tgz",
       "integrity": "sha512-9PlYgGV7Ey2haPNyWkNn719Wj5OjQUwLfvDR/XTQAJTgso0wmsoa3eoDqX6E8s+6QkFKrT2FEC2mXpkFTTpH4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3915,14 +3916,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.105.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.8.tgz",
-      "integrity": "sha512-ZPB6Day6dYTZEfi8UJEBbs6MiErSYuXT7PTaTeqBNZmQHc9sg8ieqH4yawOLKiV1Z/w5ryfF3ecBWNmwz0OY1Q==",
+      "version": "0.105.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.9.tgz",
+      "integrity": "sha512-jvMgnT9NF7eeUf0MMVgwNtY+3mOLXSaftTp1sUquw8XGjdspNg+FZWdHUL6ixPuIuB1z8iqTPY1nfNy3b8HTQw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/jsonc-parser": "^1.5.0",
-        "@lvce-editor/shared-process": "0.105.8",
-        "@lvce-editor/static-server": "0.105.8"
+        "@lvce-editor/shared-process": "0.105.9",
+        "@lvce-editor/static-server": "0.105.9"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3931,10 +3932,65 @@
         "node": ">=24"
       }
     },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
+      "version": "0.105.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.9.tgz",
+      "integrity": "sha512-2X1TLvqrFWQUkKIe/S9Ur1RGSMuFvvWHiKaaFBSkOsFa22uXot+Eyd41wktRgmpKGTQTOwxpnAY4Q0Ap+n0kAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.18.0",
+        "@lvce-editor/verror": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+      "version": "0.105.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.9.tgz",
+      "integrity": "sha512-fUwCJbShXC7gmM16fWeH/iIkoPVGXTNObXs2SF0LCBypjZ8jA0nyKkkx9w1LFisNxcnz4nD7gOEHX29WL3JRAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.105.9",
+        "@lvce-editor/ipc": "16.12.0",
+        "@lvce-editor/json-rpc": "8.7.0",
+        "@lvce-editor/jsonc-parser": "1.5.0",
+        "@lvce-editor/pretty-error": "2.0.0",
+        "@lvce-editor/process-explorer": "3.19.0",
+        "@lvce-editor/rpc-registry": "9.52.0",
+        "@lvce-editor/verror": "1.7.0",
+        "is-object": "^1.0.2",
+        "markdown-it": "^15.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/auth-process": "1.17.0",
+        "@lvce-editor/embeds-process": "4.18.0",
+        "@lvce-editor/file-system-process": "5.15.1",
+        "@lvce-editor/file-watcher-process": "4.13.0",
+        "@lvce-editor/network-process": "5.2.0",
+        "@lvce-editor/preload": "1.5.0",
+        "@lvce-editor/preview-process": "11.0.0",
+        "@lvce-editor/pty-host": "8.8.0",
+        "@lvce-editor/search-process": "15.8.0",
+        "@lvce-editor/typescript-compile-process": "5.10.1",
+        "open": "^11.0.1",
+        "tail": "^2.2.6",
+        "tmp-promise": "^3.0.3",
+        "trash": "^10.1.1"
+      }
+    },
     "node_modules/@lvce-editor/shared-process": {
       "version": "0.105.8",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.8.tgz",
       "integrity": "sha512-RNpKSkwgY80YJkarT3/XK3GwlRUibgO5Mn41pliqU8qAJYedtklujhjokM4513At5vT2sJUiYI+uujO6TfuWew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
@@ -3971,9 +4027,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.105.8",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.8.tgz",
-      "integrity": "sha512-gyJAlZmthuxwDflB6m4m45pK64rq1WWm5AR8MvzU87TU5TEX4pTt/kVQ+XTq5g0OioiyFziuN/zzo4xnUlZLGw==",
+      "version": "0.105.9",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.9.tgz",
+      "integrity": "sha512-hQeQIfDUHmWg4XmxzfK7nO/0mCHlS8lJZLjrZI10Qny33t59nSHUOZTxAVavsHygZu1I4/ipoJ+J+S0N0of3yw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -15986,7 +16042,7 @@
         "@babel/preset-typescript": "^7.29.7",
         "@lvce-editor/measure-memory": "^3.11.0",
         "@lvce-editor/shared-process": "0.105.8",
-        "@lvce-editor/static-server": "0.105.8",
+        "@lvce-editor/static-server": "0.105.9",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/node": "^25.5.0",
@@ -16056,8 +16112,8 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/drag-and-drop-worker": "0.6.0",
-        "@lvce-editor/server": "0.105.8",
-        "@lvce-editor/static-server": "0.105.8"
+        "@lvce-editor/server": "0.105.9",
+        "@lvce-editor/static-server": "0.105.9"
       },
       "devDependencies": {
         "@types/node": "^25.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3916,14 +3916,14 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.105.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.9.tgz",
-      "integrity": "sha512-jvMgnT9NF7eeUf0MMVgwNtY+3mOLXSaftTp1sUquw8XGjdspNg+FZWdHUL6ixPuIuB1z8iqTPY1nfNy3b8HTQw==",
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.105.14.tgz",
+      "integrity": "sha512-4UA1VJaVFwz/P450T1wIEThSq3ZEy4acf8DBIBD8gVKOC3ZvGYbPiH3IY8yBnPybA5apxLni23luHsRIaEdpDw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/jsonc-parser": "^1.5.0",
-        "@lvce-editor/shared-process": "0.105.9",
-        "@lvce-editor/static-server": "0.105.9"
+        "@lvce-editor/shared-process": "0.105.14",
+        "@lvce-editor/static-server": "0.105.14"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3933,9 +3933,9 @@
       }
     },
     "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.105.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.9.tgz",
-      "integrity": "sha512-2X1TLvqrFWQUkKIe/S9Ur1RGSMuFvvWHiKaaFBSkOsFa22uXot+Eyd41wktRgmpKGTQTOwxpnAY4Q0Ap+n0kAg==",
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.105.14.tgz",
+      "integrity": "sha512-hL1cqUgk7Q5PQhLAZcWOU8DD9u0x0SOQFQ7y6zXYcCY5rKnvBl/gmBCGlqZiFDB/W+Rw9nzHoWMxPnGEaCvSWw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.9.0",
@@ -3948,13 +3948,13 @@
       }
     },
     "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
-      "version": "0.105.9",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.9.tgz",
-      "integrity": "sha512-fUwCJbShXC7gmM16fWeH/iIkoPVGXTNObXs2SF0LCBypjZ8jA0nyKkkx9w1LFisNxcnz4nD7gOEHX29WL3JRAw==",
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.105.14.tgz",
+      "integrity": "sha512-1rLXhd1hhQ6ci46UKXoN34+oSU+2rE/Gso5VoafSl+omPXi9hBaOf7lW2Cw1MeXflCCzHTfrxQCJts8/k6vmlA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.105.9",
+        "@lvce-editor/extension-host-helper-process": "0.105.14",
         "@lvce-editor/ipc": "16.12.0",
         "@lvce-editor/json-rpc": "8.7.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3984,6 +3984,15 @@
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
         "trash": "^10.1.1"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/static-server": {
+      "version": "0.105.14",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.105.14.tgz",
+      "integrity": "sha512-m0y2Nmmubj0Bos1KyRuQ+Qipsu5f1aDdECvzqRM5upkjWMvyvgMMlvU2nSehJxfiGkYK0+auR08LQLsmwQfzqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/shared-process": {
@@ -16112,7 +16121,7 @@
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/drag-and-drop-worker": "0.6.0",
-        "@lvce-editor/server": "0.105.9",
+        "@lvce-editor/server": "0.105.14",
         "@lvce-editor/static-server": "0.105.9"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2907,9 +2907,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.28.0.tgz",
-      "integrity": "sha512-6ESs02HAc2xYkZjIZOy74SY7R19xXbetdBPkJUXZUTI7rozHrGSf9LkBHcyt7UB1gSct7z8LrVFesMdj2N6RLg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.29.0.tgz",
+      "integrity": "sha512-u7nBvomSMewNt7uqavJPFeu4XzknQqrngeW2Rv8Y03FEsX68+XmAr7yNykq39zOAAqsvMBeIDDkpZj6y87e6TA==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/drag-and-drop-worker": {
@@ -16011,15 +16011,27 @@
       "devDependencies": {
         "@jest/globals": "^30.4.1",
         "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/constants": "^5.28.0",
+        "@lvce-editor/constants": "^5.29.0",
         "@lvce-editor/i18n": "^2.9.0",
         "@lvce-editor/rpc": "^6.18.0",
-        "@lvce-editor/rpc-registry": "^9.51.0",
+        "@lvce-editor/rpc-registry": "^9.53.1",
         "@lvce-editor/verror": "^1.7.0",
         "@lvce-editor/viewlet-registry": "^5.10.0",
         "@lvce-editor/virtual-dom-worker": "^11.12.2",
         "jest": "^30.4.2",
         "ts-jest": "^29.4.12"
+      }
+    },
+    "packages/explorer-view/node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.53.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.53.1.tgz",
+      "integrity": "sha512-ZUMo4sATd5dQxVrwoOKsjHohL18YyTPmFbvY0lmuayi8kyWH6Dt7yHuO0lRtKHSJ4JU+6DFhKxqmsUadHr4mdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.29.0",
+        "@lvce-editor/rpc": "^6.4.0"
       }
     },
     "packages/server": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.29.7",
     "@lvce-editor/measure-memory": "^3.11.0",
-    "@lvce-editor/shared-process": "0.105.5",
-    "@lvce-editor/static-server": "0.105.5",
+    "@lvce-editor/shared-process": "0.105.8",
+    "@lvce-editor/static-server": "0.105.8",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/node": "^25.5.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.29.7",
     "@lvce-editor/measure-memory": "^3.11.0",
-    "@lvce-editor/shared-process": "0.105.8",
-    "@lvce-editor/static-server": "0.105.9",
+    "@lvce-editor/shared-process": "0.105.14",
+    "@lvce-editor/static-server": "0.105.14",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/node": "^25.5.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@babel/preset-typescript": "^7.29.7",
     "@lvce-editor/measure-memory": "^3.11.0",
-    "@lvce-editor/shared-process": "0.100.25",
-    "@lvce-editor/static-server": "0.100.25",
+    "@lvce-editor/shared-process": "0.105.5",
+    "@lvce-editor/static-server": "0.105.5",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/node": "^25.5.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-typescript": "^7.29.7",
     "@lvce-editor/measure-memory": "^3.11.0",
     "@lvce-editor/shared-process": "0.105.8",
-    "@lvce-editor/static-server": "0.105.8",
+    "@lvce-editor/static-server": "0.105.9",
     "@rollup/plugin-babel": "^7.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/node": "^25.5.0",

--- a/packages/build/src/measureMemory.ts
+++ b/packages/build/src/measureMemory.ts
@@ -2,7 +2,7 @@ import { measureMemory } from '@lvce-editor/measure-memory'
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-const threshold = 613_000
+const threshold = 614_000
 
 const instantiations = 200_000
 

--- a/packages/explorer-view/package.json
+++ b/packages/explorer-view/package.json
@@ -47,10 +47,10 @@
   "devDependencies": {
     "@jest/globals": "^30.4.1",
     "@lvce-editor/assert": "^1.9.0",
-    "@lvce-editor/constants": "^5.28.0",
+    "@lvce-editor/constants": "^5.29.0",
     "@lvce-editor/i18n": "^2.9.0",
     "@lvce-editor/rpc": "^6.18.0",
-    "@lvce-editor/rpc-registry": "^9.51.0",
+    "@lvce-editor/rpc-registry": "^9.53.1",
     "@lvce-editor/verror": "^1.7.0",
     "@lvce-editor/viewlet-registry": "^5.10.0",
     "@lvce-editor/virtual-dom-worker": "^11.12.2",

--- a/packages/explorer-view/src/parts/GetDroppedItems/GetDroppedItems.ts
+++ b/packages/explorer-view/src/parts/GetDroppedItems/GetDroppedItems.ts
@@ -7,8 +7,11 @@ export interface ExplorerDroppedItems {
   readonly uris: readonly string[]
 }
 
-export const getDroppedItems = async (itemIds: readonly number[], isElectron: boolean): Promise<ExplorerDroppedItems> => {
-  const result = await DragAndDropWorker.getDroppedItems(itemIds, isElectron)
+export const getDroppedItems = async (dropIdOrItemIds: number | readonly number[], isElectron: boolean): Promise<ExplorerDroppedItems> => {
+  const result =
+    typeof dropIdOrItemIds === 'number'
+      ? await DragAndDropWorker.getDroppedItemsByDropId(dropIdOrItemIds, isElectron)
+      : await DragAndDropWorker.getDroppedItems(dropIdOrItemIds, isElectron)
   const files = isElectron ? result.files : result.files.filter((file) => file.handle)
   const fileHandles = files.map((file) => file.handle || ({ kind: file.kind, name: file.name } as FileSystemHandle))
   const paths = files.map((file) => file.path)

--- a/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
+++ b/packages/explorer-view/src/parts/HandleDrop/HandleDrop.ts
@@ -1,3 +1,4 @@
+import { DragAndDropWorker } from '@lvce-editor/rpc-registry'
 import type { ExplorerState } from '../ExplorerState/ExplorerState.ts'
 import { getDropHandler } from '../GetDropHandler/GetDropHandler.ts'
 import { getDroppedItems } from '../GetDroppedItems/GetDroppedItems.ts'
@@ -6,13 +7,16 @@ import { getInternalDragPaths } from '../GetInternalDragPaths/GetInternalDragPat
 import * as PlatformType from '../PlatformType/PlatformType.ts'
 import { VError } from '../VError/VError.ts'
 
-export const handleDrop = async (state: ExplorerState, x: number, y: number, fileIds: readonly number[]): Promise<ExplorerState> => {
+export const handleDrop = async (state: ExplorerState, x: number, y: number, dropIdOrFileIds: number | readonly number[]): Promise<ExplorerState> => {
   if (state.isReadonly && state.root !== '') {
+    if (typeof dropIdOrFileIds === 'number') {
+      await DragAndDropWorker.discardDrop(dropIdOrFileIds)
+    }
     return state
   }
   try {
     const isElectron = state.platform === PlatformType.Electron
-    const { fileHandles, paths, uris } = await getDroppedItems(fileIds, isElectron)
+    const { fileHandles, paths, uris } = await getDroppedItems(dropIdOrFileIds, isElectron)
     const internalPaths = getInternalDragPaths(state.items, uris)
     const droppedPaths = internalPaths.length > 0 ? internalPaths : paths
     const index = GetIndexFromPosition.getIndexFromPosition(state, x, y)

--- a/packages/explorer-view/src/parts/Render2/Render2.ts
+++ b/packages/explorer-view/src/parts/Render2/Render2.ts
@@ -15,5 +15,5 @@ export const render2 = async (uid: number, _diffResult: readonly number[]): Prom
   const rendererWorkerCommands = commands.filter((command) => command[0] === ViewletCommand.SetFocusContext)
   const rendererProcessCommands = commands.filter((command) => command[0] !== ViewletCommand.SetFocusContext)
   const transactionId = await RendererProcess.invoke('Viewlet.queueCommands', uid, rendererProcessCommands)
-  return [...rendererWorkerCommands, ['Viewlet.commitPending', uid, transactionId]]
+  return [['Viewlet.commitPending', uid, transactionId], ...rendererWorkerCommands]
 }

--- a/packages/explorer-view/src/parts/Render2/Render2.ts
+++ b/packages/explorer-view/src/parts/Render2/Render2.ts
@@ -5,9 +5,9 @@ import * as ExplorerStates from '../ExplorerStates/ExplorerStates.ts'
 import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const render2 = async (uid: number, _diffResult: readonly number[]): Promise<readonly any[]> => {
-  const { oldState, scheduledState } = ExplorerStates.get(uid)
+  const { newState, oldState, scheduledState } = ExplorerStates.get(uid)
   const diffResult = Diff.diff(oldState, scheduledState)
-  ExplorerStates.set(uid, scheduledState, scheduledState)
+  ExplorerStates.set(uid, scheduledState, newState, scheduledState)
   const commands = ApplyRender.applyRender(oldState, scheduledState, diffResult)
   if (!RendererProcess.isConnected()) {
     return commands

--- a/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
+++ b/packages/explorer-view/src/parts/RenderEventListeners/RenderEventListeners.ts
@@ -95,7 +95,7 @@ export const renderEventListeners = (): readonly DomEventListener[] => {
     },
     {
       name: DomEventListenersFunctions.HandleDrop,
-      params: ['handleDrop', EventExpression.ClientX, EventExpression.ClientY, EventExpression.DataTransferFiles2],
+      params: ['handleDrop', EventExpression.ClientX, EventExpression.ClientY, EventExpression.DropId],
       preventDefault: true,
     },
     {

--- a/packages/explorer-view/test/GetDroppedItems.test.ts
+++ b/packages/explorer-view/test/GetDroppedItems.test.ts
@@ -38,3 +38,23 @@ test('keeps path-only electron files', async () => {
     uris: ['file:///tmp/legacy.txt'],
   })
 })
+
+test('resolves opt-in drop data by drop id', async () => {
+  const handle = { kind: 'file', name: 'notes.txt' }
+  using dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.getDroppedItemsByDropId'() {
+      return {
+        files: [{ handle, kind: 'file', name: 'notes.txt', path: '', uri: 'html:///notes.txt' }],
+        strings: [],
+        uris: ['html:///notes.txt'],
+      }
+    },
+  })
+
+  await expect(getDroppedItems(17, false)).resolves.toEqual({
+    fileHandles: [handle],
+    paths: [''],
+    uris: ['html:///notes.txt'],
+  })
+  expect(dragRpc.invocations).toEqual([['DragAndDrop.getDroppedItemsByDropId', 17, false]])
+})

--- a/packages/explorer-view/test/HandleDrop.test.ts
+++ b/packages/explorer-view/test/HandleDrop.test.ts
@@ -27,6 +27,20 @@ test('handleDrop - successful drop', async () => {
   expect(mockRpc.invocations).toEqual([['FileSystem.readDirWithFileTypes', '/']])
 })
 
+test('handleDrop - discards an opt-in drop for a readonly workspace', async () => {
+  using dragRpc = DragAndDropWorker.registerMockRpc({
+    'DragAndDrop.discardDrop'() {},
+  })
+  const state = {
+    ...createDefaultState(),
+    isReadonly: true,
+    root: '/workspace',
+  }
+
+  await expect(handleDrop(state, 0, 0, 21)).resolves.toBe(state)
+  expect(dragRpc.invocations).toEqual([['DragAndDrop.discardDrop', 21]])
+})
+
 test('handleDrop - error case', async () => {
   using dragRpc = DragAndDropWorker.registerMockRpc({
     'DragAndDrop.getDroppedItems'() {

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -22,7 +22,7 @@ test('render2 - returns renderer commands when no direct renderer is connected',
 
 test('render2 - preserves state changes that were not scheduled for rendering', async () => {
   const uid = 4
-  const renderedState = { ...createDefaultState(), uid, focusWord: 'b' }
+  const renderedState = { ...createDefaultState(), focusWord: 'b', uid }
   const currentState = { ...renderedState, focusWord: '' }
   ExplorerStates.set(uid, renderedState, currentState, renderedState)
 

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -55,7 +55,7 @@ test('render2 - leaves focus context management with the renderer worker', async
 
   expect(queueCommands).toHaveBeenCalledWith(uid, [['Viewlet.focusSelector', uid, '.ListItems']])
   expect(result).toEqual([
-    ['Viewlet.setFocusContext', uid, WhenExpression.FocusExplorer],
     ['Viewlet.commitPending', uid, 23],
+    ['Viewlet.setFocusContext', uid, WhenExpression.FocusExplorer],
   ])
 })

--- a/packages/explorer-view/test/Render2.test.ts
+++ b/packages/explorer-view/test/Render2.test.ts
@@ -20,6 +20,21 @@ test('render2 - returns renderer commands when no direct renderer is connected',
   await expect(Render2.render2(uid, [])).resolves.toEqual([['Viewlet.setPatches', uid, []]])
 })
 
+test('render2 - preserves state changes that were not scheduled for rendering', async () => {
+  const uid = 4
+  const renderedState = { ...createDefaultState(), uid, focusWord: 'b' }
+  const currentState = { ...renderedState, focusWord: '' }
+  ExplorerStates.set(uid, renderedState, currentState, renderedState)
+
+  await Render2.render2(uid, [])
+
+  expect(ExplorerStates.get(uid)).toEqual({
+    newState: currentState,
+    oldState: renderedState,
+    scheduledState: renderedState,
+  })
+})
+
 test('render2 - queues renderer commands and returns a lightweight commit marker', async () => {
   const queueCommands = jest.fn((_uid: number, _commands: readonly unknown[]) => 17)
   RendererProcess.set(

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "@lvce-editor/drag-and-drop-worker": "0.6.0",
-    "@lvce-editor/server": "0.105.9",
+    "@lvce-editor/server": "0.105.14",
     "@lvce-editor/static-server": "0.105.9"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@lvce-editor/drag-and-drop-worker": "0.6.0",
     "@lvce-editor/server": "0.105.14",
-    "@lvce-editor/static-server": "0.105.9"
+    "@lvce-editor/static-server": "0.105.14"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,8 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "@lvce-editor/drag-and-drop-worker": "0.6.0",
-    "@lvce-editor/server": "0.105.5",
-    "@lvce-editor/static-server": "0.105.5"
+    "@lvce-editor/server": "0.105.8",
+    "@lvce-editor/static-server": "0.105.8"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,9 +11,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/drag-and-drop-worker": "0.4.0",
-    "@lvce-editor/server": "0.100.25",
-    "@lvce-editor/static-server": "0.100.25"
+    "@lvce-editor/drag-and-drop-worker": "0.6.0",
+    "@lvce-editor/server": "0.105.5",
+    "@lvce-editor/static-server": "0.105.5"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,8 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "@lvce-editor/drag-and-drop-worker": "0.6.0",
-    "@lvce-editor/server": "0.105.8",
-    "@lvce-editor/static-server": "0.105.8"
+    "@lvce-editor/server": "0.105.9",
+    "@lvce-editor/static-server": "0.105.9"
   },
   "devDependencies": {
     "@types/node": "^25.9.3"

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -58,18 +58,18 @@ const dragAndDropWorkerMainPath = join(dirname(dragAndDropWorkerPackagePath), 'd
 const dragAndDropWorkerRemoteUrl = getRemoteUrl(dragAndDropWorkerMainPath)
 const dragAndDropCommand = 'SendMessagePortToExtensionHostWorker.sendMessagePortToDragAndDropWorker'
 let rendererWorkerContent = await readFile(rendererWorkerMainPath, 'utf-8')
-const retainedFileHandles = `const getFileHandles = async ids => {
-  const handles = await invoke$I('FileHandles.get', ids);
-  return handles.map(value => ({ kind: 'file', type: '', value }));
-};`
-if (!rendererWorkerContent.includes(retainedFileHandles)) {
-  const occurrence = `const getFileHandles = ids => {
-  return invoke$I('FileHandles.get', ids);
-};`
-  if (!rendererWorkerContent.includes(occurrence)) {
+const retainedFileHandles =
+  /const getFileHandles = async ids => \{\n  const handles = await invoke[^\n(]*\('FileHandles\.get', ids\);\n  return handles\.map\(value => \(\{ kind: 'file', type: '', value \}\)\);\n\};/
+if (!retainedFileHandles.test(rendererWorkerContent)) {
+  const occurrence = /const getFileHandles = ids => \{\n  return (invoke[^\n(]*)\('FileHandles\.get', ids\);\n\};/
+  if (!occurrence.test(rendererWorkerContent)) {
     throw new Error('renderer retained file handles occurrence not found')
   }
-  rendererWorkerContent = rendererWorkerContent.replace(occurrence, retainedFileHandles)
+  const replacement = `const getFileHandles = async ids => {
+  const handles = await $1('FileHandles.get', ids);
+  return handles.map(value => ({ kind: 'file', type: '', value }));
+};`
+  rendererWorkerContent = rendererWorkerContent.replace(occurrence, replacement)
 }
 if (!rendererWorkerContent.includes(dragAndDropCommand)) {
   const commandOccurrence = `  'SendMessagePortToExtensionHostWorker.sendMessagePortToEditorWorker': lazy('SendMessagePortToExtensionHostWorker.sendMessagePortToEditorWorker'),`
@@ -124,15 +124,17 @@ await writeFile(rendererWorkerMainPath, rendererWorkerContent)
 
 const testWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'test-worker', 'dist', 'testWorkerMain.js')
 const testWorkerContent = await readFile(testWorkerMainPath, 'utf-8')
-const resetOccurrence = `    await invoke$1('Layout.reset');`
-const resetReplacement = `    await invoke$1('FileSystem.remove', 'memfs:///workspace');
-    await invoke$1('Layout.reset');
-    await invoke$1('Layout.hideSideBar');
-    await invoke$1('Layout.showSideBar');`
+const resetOccurrence = /    await (invoke[^\n(]*)\('Layout\.reset'\);/
+const resetReplacement =
+  /    await invoke[^\n(]*\('FileSystem\.remove', 'memfs:\/\/\/workspace'\);\n    await invoke[^\n(]*\('Layout\.reset'\);\n    await invoke[^\n(]*\('Layout\.hideSideBar'\);\n    await invoke[^\n(]*\('Layout\.showSideBar'\);/
 
-if (!testWorkerContent.includes(resetReplacement)) {
-  if (!testWorkerContent.includes(resetOccurrence)) {
+if (!resetReplacement.test(testWorkerContent)) {
+  if (!resetOccurrence.test(testWorkerContent)) {
     throw new Error('test worker reset occurrence not found')
   }
-  await writeFile(testWorkerMainPath, testWorkerContent.replace(resetOccurrence, resetReplacement))
+  const replacement = `    await $1('FileSystem.remove', 'memfs:///workspace');
+    await $1('Layout.reset');
+    await $1('Layout.hideSideBar');
+    await $1('Layout.showSideBar');`
+  await writeFile(testWorkerMainPath, testWorkerContent.replace(resetOccurrence, replacement))
 }

--- a/packages/server/src/postinstall.js
+++ b/packages/server/src/postinstall.js
@@ -126,13 +126,14 @@ const testWorkerMainPath = join(serverStaticPath, commitHash, 'packages', 'test-
 const testWorkerContent = await readFile(testWorkerMainPath, 'utf-8')
 const resetOccurrence = /    await (invoke[^\n(]*)\('Layout\.reset'\);/
 const resetReplacement =
-  /    await invoke[^\n(]*\('FileSystem\.remove', 'memfs:\/\/\/workspace'\);\n    await invoke[^\n(]*\('Layout\.reset'\);\n    await invoke[^\n(]*\('Layout\.hideSideBar'\);\n    await invoke[^\n(]*\('Layout\.showSideBar'\);/
+  /    await invoke[^\n(]*\('FileSystem\.remove', 'memfs:\/\/\/workspace'\);\n    await invoke[^\n(]*\('FileSystem\.mkdir', 'memfs:\/\/\/workspace'\);\n    await invoke[^\n(]*\('Layout\.reset'\);\n    await invoke[^\n(]*\('Layout\.hideSideBar'\);\n    await invoke[^\n(]*\('Layout\.showSideBar'\);/
 
 if (!resetReplacement.test(testWorkerContent)) {
   if (!resetOccurrence.test(testWorkerContent)) {
     throw new Error('test worker reset occurrence not found')
   }
   const replacement = `    await $1('FileSystem.remove', 'memfs:///workspace');
+    await $1('FileSystem.mkdir', 'memfs:///workspace');
     await $1('Layout.reset');
     await $1('Layout.hideSideBar');
     await $1('Layout.showSideBar');`


### PR DESCRIPTION
Switch Explorer drops to event.dropId while preserving legacy item-id arrays. Resolve normalized dropped items through drag-and-drop-worker and explicitly discard sessions for ignored readonly drops.

Align the build and test server runtime on 0.105.8 and keep workspace reset setup compatible with validated workspaces.

Validation:
- build and static build
- type-check, complete unit suite, and lint
- drop-folder-empty-workspace browser e2e against server/static-server 0.105.8